### PR TITLE
[Feature] 콘텐츠 엔진 admin 연동 — 초안 관리 및 트렌드 리포트

### DIFF
--- a/admin/src/app/content-engine/actions.ts
+++ b/admin/src/app/content-engine/actions.ts
@@ -1,0 +1,27 @@
+'use server';
+
+import { updateDraftStatus, updateDraftCaption } from '@/lib/queries/content-engine';
+import { revalidatePath } from 'next/cache';
+
+export async function approveDraft(id: string) {
+  await updateDraftStatus(id, 'approved');
+  revalidatePath('/content-engine');
+  revalidatePath('/content-engine/drafts');
+}
+
+export async function publishDraft(id: string) {
+  await updateDraftStatus(id, 'published');
+  revalidatePath('/content-engine');
+  revalidatePath('/content-engine/drafts');
+}
+
+export async function rejectDraft(id: string, note?: string) {
+  await updateDraftStatus(id, 'rejected', note);
+  revalidatePath('/content-engine');
+  revalidatePath('/content-engine/drafts');
+}
+
+export async function editDraftCaption(id: string, caption: string) {
+  await updateDraftCaption(id, caption);
+  revalidatePath('/content-engine/drafts');
+}

--- a/admin/src/app/content-engine/drafts/DraftActions.tsx
+++ b/admin/src/app/content-engine/drafts/DraftActions.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useTransition } from 'react';
+import { Button } from '@/components/ui/button';
+import { approveDraft, publishDraft, rejectDraft } from '../actions';
+import { toast } from 'sonner';
+import { CheckCircle, Send, X, Loader2 } from 'lucide-react';
+
+interface DraftActionsProps {
+  id: string;
+  status: string;
+}
+
+export function DraftActions({ id, status }: DraftActionsProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleApprove = () => {
+    startTransition(async () => {
+      try {
+        await approveDraft(id);
+        toast.success('초안이 승인되었습니다');
+      } catch {
+        toast.error('승인 처리 중 오류가 발생했습니다');
+      }
+    });
+  };
+
+  const handlePublish = () => {
+    startTransition(async () => {
+      try {
+        await publishDraft(id);
+        toast.success('콘텐츠가 발행되었습니다');
+      } catch {
+        toast.error('발행 처리 중 오류가 발생했습니다');
+      }
+    });
+  };
+
+  const handleReject = () => {
+    startTransition(async () => {
+      try {
+        await rejectDraft(id);
+        toast.success('초안이 반려되었습니다');
+      } catch {
+        toast.error('반려 처리 중 오류가 발생했습니다');
+      }
+    });
+  };
+
+  if (status === 'published') {
+    return <p className="text-xs text-muted-foreground">발행 완료</p>;
+  }
+
+  return (
+    <div className="flex gap-2 border-t pt-3">
+      {isPending && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+
+      {status === 'draft' && (
+        <>
+          <Button size="sm" variant="default" onClick={handleApprove} disabled={isPending}>
+            <CheckCircle className="mr-1 h-3 w-3" />
+            승인
+          </Button>
+          <Button size="sm" variant="destructive" onClick={handleReject} disabled={isPending}>
+            <X className="mr-1 h-3 w-3" />
+            반려
+          </Button>
+        </>
+      )}
+
+      {status === 'approved' && (
+        <Button size="sm" variant="default" onClick={handlePublish} disabled={isPending}>
+          <Send className="mr-1 h-3 w-3" />
+          발행
+        </Button>
+      )}
+
+      {status === 'rejected' && (
+        <Button size="sm" variant="outline" onClick={handleApprove} disabled={isPending}>
+          <CheckCircle className="mr-1 h-3 w-3" />
+          재승인
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/admin/src/app/content-engine/drafts/page.tsx
+++ b/admin/src/app/content-engine/drafts/page.tsx
@@ -1,0 +1,158 @@
+import { getDrafts } from '@/lib/queries/content-engine';
+import { AdminLayout } from '@/components/layout/AdminLayout';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { DraftActions } from './DraftActions';
+import Link from 'next/link';
+
+const TIME_SLOT_LABEL: Record<string, string> = {
+  morning: '🌅 오전',
+  lunch: '☀️ 점심',
+  evening: '🌙 저녁',
+};
+
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'outline' | 'destructive'> = {
+  draft: 'secondary',
+  approved: 'default',
+  published: 'outline',
+  rejected: 'destructive',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: '초안',
+  approved: '승인됨',
+  published: '발행됨',
+  rejected: '반려',
+};
+
+interface PageProps {
+  searchParams: Promise<{ status?: string; page?: string }>;
+}
+
+export default async function DraftsPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const status = params.status;
+  const page = parseInt(params.page ?? '1', 10);
+  const limit = 12;
+  const offset = (page - 1) * limit;
+
+  const { drafts, total } = await getDrafts({ status, limit, offset });
+  const totalPages = Math.ceil(total / limit);
+
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">초안 관리</h1>
+          <Link
+            href="/content-engine"
+            className="text-sm text-muted-foreground hover:underline"
+          >
+            ← 콘텐츠 엔진
+          </Link>
+        </div>
+
+        {/* 필터 탭 */}
+        <div className="flex gap-2">
+          {[
+            { label: '전체', value: undefined },
+            { label: '검토 대기', value: 'draft' },
+            { label: '승인됨', value: 'approved' },
+            { label: '발행됨', value: 'published' },
+            { label: '반려', value: 'rejected' },
+          ].map((tab) => (
+            <Link
+              key={tab.label}
+              href={`/content-engine/drafts${tab.value ? `?status=${tab.value}` : ''}`}
+              className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+                status === tab.value
+                  ? 'bg-primary text-primary-foreground'
+                  : !status && !tab.value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {tab.label}
+            </Link>
+          ))}
+        </div>
+
+        {/* 초안 카드 목록 */}
+        {drafts.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center text-muted-foreground">
+              해당 조건의 초안이 없습니다
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {drafts.map((draft) => (
+              <Card key={draft.id} className="flex flex-col">
+                <CardContent className="flex flex-1 flex-col gap-3 pt-5">
+                  {/* 헤더 */}
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium">{draft.report_date}</span>
+                      <span className="text-sm">{TIME_SLOT_LABEL[draft.time_slot]}</span>
+                    </div>
+                    <Badge variant={STATUS_VARIANT[draft.status]}>
+                      {STATUS_LABEL[draft.status]}
+                    </Badge>
+                  </div>
+
+                  {/* 캡션 */}
+                  <p className="flex-1 text-sm leading-relaxed text-foreground">
+                    {draft.caption || '(캡션 없음)'}
+                  </p>
+
+                  {/* 해시태그 */}
+                  {draft.hashtags.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {draft.hashtags.slice(0, 6).map((tag) => (
+                        <span key={tag} className="text-xs text-sky-600">
+                          #{tag}
+                        </span>
+                      ))}
+                      {draft.hashtags.length > 6 && (
+                        <span className="text-xs text-muted-foreground">+{draft.hashtags.length - 6}</span>
+                      )}
+                    </div>
+                  )}
+
+                  {/* 참조 장소 */}
+                  {draft.referenced_places.length > 0 && (
+                    <div className="text-xs text-muted-foreground">
+                      📍 {draft.referenced_places.join(', ')}
+                    </div>
+                  )}
+
+                  {/* 액션 버튼 */}
+                  <DraftActions id={draft.id} status={draft.status} />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {/* 페이지네이션 */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2">
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
+              <Link
+                key={p}
+                href={`/content-engine/drafts?${status ? `status=${status}&` : ''}page=${p}`}
+                className={`rounded px-3 py-1 text-sm ${
+                  p === page
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {p}
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </AdminLayout>
+  );
+}

--- a/admin/src/app/content-engine/page.tsx
+++ b/admin/src/app/content-engine/page.tsx
@@ -1,0 +1,177 @@
+import { getContentEngineStats } from '@/lib/queries/content-engine';
+import { AdminLayout } from '@/components/layout/AdminLayout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { FileText, CheckCircle, Send, TrendingUp, MessageSquare, Bot } from 'lucide-react';
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+
+const TIME_SLOT_LABEL: Record<string, string> = {
+  morning: '🌅 오전',
+  lunch: '☀️ 점심',
+  evening: '🌙 저녁',
+};
+
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'outline' | 'destructive'> = {
+  draft: 'secondary',
+  approved: 'default',
+  published: 'outline',
+  rejected: 'destructive',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: '초안',
+  approved: '승인됨',
+  published: '발행됨',
+  rejected: '반려',
+};
+
+export default async function ContentEnginePage() {
+  const stats = await getContentEngineStats();
+
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">콘텐츠 엔진</h1>
+          <div className="flex gap-2">
+            <Link
+              href="/content-engine/drafts"
+              className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              <FileText className="h-4 w-4" />
+              초안 관리
+            </Link>
+            <Link
+              href="/content-engine/trends"
+              className="inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium hover:bg-muted"
+            >
+              <TrendingUp className="h-4 w-4" />
+              트렌드 리포트
+            </Link>
+          </div>
+        </div>
+
+        {/* 통계 카드 */}
+        <div className="grid gap-4 md:grid-cols-3 lg:grid-cols-6">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">전체 초안</CardTitle>
+              <FileText className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold">{stats.totalDrafts}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">검토 대기</CardTitle>
+              <Bot className="h-4 w-4 text-amber-500" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold text-amber-600">{stats.pendingDrafts}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">승인됨</CardTitle>
+              <CheckCircle className="h-4 w-4 text-emerald-500" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold text-emerald-600">{stats.approvedDrafts}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">발행됨</CardTitle>
+              <Send className="h-4 w-4 text-sky-500" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold text-sky-600">{stats.publishedDrafts}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">트렌드 리포트</CardTitle>
+              <TrendingUp className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold">{stats.totalReports}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">수집된 SNS</CardTitle>
+              <MessageSquare className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold">{stats.totalSnsPosts}</div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {/* 최근 초안 */}
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle className="text-sm font-medium">최근 생성된 초안</CardTitle>
+              <Link href="/content-engine/drafts" className="text-xs text-muted-foreground hover:underline">
+                전체 보기 →
+              </Link>
+            </CardHeader>
+            <CardContent>
+              {stats.recentDrafts.length === 0 ? (
+                <p className="text-sm text-muted-foreground">아직 생성된 초안이 없습니다</p>
+              ) : (
+                <div className="space-y-3">
+                  {stats.recentDrafts.map((draft) => (
+                    <div key={draft.id} className="flex items-start justify-between gap-2 text-sm">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs text-muted-foreground">{draft.report_date}</span>
+                          <span className="text-xs">{TIME_SLOT_LABEL[draft.time_slot] ?? draft.time_slot}</span>
+                          <Badge variant={STATUS_VARIANT[draft.status] ?? 'secondary'}>
+                            {STATUS_LABEL[draft.status] ?? draft.status}
+                          </Badge>
+                        </div>
+                        <p className="mt-1 truncate text-muted-foreground">{draft.caption}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* 최근 트렌드 리포트 */}
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle className="text-sm font-medium">최근 트렌드 리포트</CardTitle>
+              <Link href="/content-engine/trends" className="text-xs text-muted-foreground hover:underline">
+                전체 보기 →
+              </Link>
+            </CardHeader>
+            <CardContent>
+              {stats.recentReports.length === 0 ? (
+                <p className="text-sm text-muted-foreground">아직 트렌드 리포트가 없습니다</p>
+              ) : (
+                <div className="space-y-3">
+                  {stats.recentReports.map((report) => (
+                    <div key={report.report_date} className="flex items-center justify-between text-sm">
+                      <div>
+                        <span className="font-medium">{report.report_date}</span>
+                        <span className="ml-2 text-muted-foreground">{report.region}</span>
+                      </div>
+                      <span className="text-xs text-muted-foreground">
+                        {report.total_posts_analyzed}개 게시물 분석
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/admin/src/app/content-engine/trends/page.tsx
+++ b/admin/src/app/content-engine/trends/page.tsx
@@ -1,0 +1,168 @@
+import { getTrendReports } from '@/lib/queries/content-engine';
+import type { PlaceTrend, KeywordTrend } from '@/lib/queries/content-engine';
+import { AdminLayout } from '@/components/layout/AdminLayout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import Link from 'next/link';
+
+const CATEGORY_LABEL: Record<string, string> = {
+  cafe: '카페',
+  restaurant: '음식점',
+  bar: '바',
+  shop: '상점',
+  gallery: '갤러리',
+  other: '기타',
+};
+
+interface PageProps {
+  searchParams: Promise<{ page?: string }>;
+}
+
+export default async function TrendsPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const page = parseInt(params.page ?? '1', 10);
+  const limit = 7;
+  const offset = (page - 1) * limit;
+
+  const { reports, total } = await getTrendReports({ limit, offset });
+  const totalPages = Math.ceil(total / limit);
+
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">트렌드 리포트</h1>
+          <Link
+            href="/content-engine"
+            className="text-sm text-muted-foreground hover:underline"
+          >
+            ← 콘텐츠 엔진
+          </Link>
+        </div>
+
+        {reports.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center text-muted-foreground">
+              아직 트렌드 리포트가 없습니다. 엔진이 실행되면 자동으로 생성됩니다.
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-6">
+            {reports.map((report) => (
+              <Card key={report.id}>
+                <CardHeader>
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-lg">
+                      {report.report_date}
+                      <span className="ml-2 text-sm font-normal text-muted-foreground">
+                        {report.region}
+                      </span>
+                    </CardTitle>
+                    <span className="text-sm text-muted-foreground">
+                      {report.total_posts_analyzed}개 게시물 분석
+                      {report.platforms && (
+                        <span className="ml-2">
+                          (IG: {report.platforms.instagram ?? 0}, Threads: {report.platforms.threads ?? 0})
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid gap-4 md:grid-cols-3">
+                    {/* 인기 장소 */}
+                    <div>
+                      <h3 className="mb-2 text-sm font-medium">인기 장소</h3>
+                      {(report.places as PlaceTrend[])?.length > 0 ? (
+                        <div className="space-y-2">
+                          {(report.places as PlaceTrend[]).slice(0, 5).map((place, i) => (
+                            <div key={i} className="flex items-center justify-between text-sm">
+                              <div className="flex items-center gap-2">
+                                <span>{place.name}</span>
+                                <Badge variant="outline" className="text-xs">
+                                  {CATEGORY_LABEL[place.category] ?? place.category}
+                                </Badge>
+                              </div>
+                              <span className="text-xs text-muted-foreground">
+                                {Math.round(place.confidence * 100)}%
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-muted-foreground">데이터 없음</p>
+                      )}
+                    </div>
+
+                    {/* 키워드 */}
+                    <div>
+                      <h3 className="mb-2 text-sm font-medium">인기 키워드</h3>
+                      {(report.top_keywords as KeywordTrend[])?.length > 0 ? (
+                        <div className="flex flex-wrap gap-1">
+                          {(report.top_keywords as KeywordTrend[]).slice(0, 12).map((kw, i) => (
+                            <Badge key={i} variant="secondary" className="text-xs">
+                              {kw.keyword}
+                              <span className="ml-1 text-muted-foreground">{kw.count}</span>
+                            </Badge>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-muted-foreground">데이터 없음</p>
+                      )}
+                    </div>
+
+                    {/* 톤 분석 */}
+                    <div>
+                      <h3 className="mb-2 text-sm font-medium">분위기</h3>
+                      {report.tone_analysis?.dominant_tone ? (
+                        <div className="space-y-2">
+                          <p className="text-sm font-medium">{report.tone_analysis.dominant_tone}</p>
+                          {report.tone_analysis.trending_expressions?.length > 0 && (
+                            <div>
+                              <p className="text-xs text-muted-foreground">자주 쓰이는 표현:</p>
+                              <div className="mt-1 flex flex-wrap gap-1">
+                                {report.tone_analysis.trending_expressions.slice(0, 6).map((expr, i) => (
+                                  <span key={i} className="text-xs text-sky-600">{expr}</span>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {report.tone_analysis.emoji_trends?.length > 0 && (
+                            <p className="text-sm">
+                              {report.tone_analysis.emoji_trends.slice(0, 8).join(' ')}
+                            </p>
+                          )}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-muted-foreground">데이터 없음</p>
+                      )}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {/* 페이지네이션 */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2">
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
+              <Link
+                key={p}
+                href={`/content-engine/trends?page=${p}`}
+                className={`rounded px-3 py-1 text-sm ${
+                  p === page
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {p}
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </AdminLayout>
+  );
+}

--- a/admin/src/components/layout/Sidebar.tsx
+++ b/admin/src/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, MapPin, AlertTriangle, Sparkles, Route } from 'lucide-react';
+import { LayoutDashboard, MapPin, AlertTriangle, Sparkles, Route, Bot } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const navItems = [
@@ -11,6 +11,7 @@ const navItems = [
   { href: '/attractions', label: '볼거리 관리', icon: Sparkles },
   { href: '/courses', label: '코스 관리', icon: Route },
   { href: '/locations/incomplete', label: '데이터 품질', icon: AlertTriangle },
+  { href: '/content-engine', label: '콘텐츠 엔진', icon: Bot },
 ];
 
 export function Sidebar() {

--- a/admin/src/lib/queries/content-engine.ts
+++ b/admin/src/lib/queries/content-engine.ts
@@ -1,0 +1,226 @@
+import { createServerSupabase } from '@/lib/supabase/server';
+
+// ── 타입 정의 ──────────────────────────────────────────────
+
+export interface GeneratedDraft {
+  id: string;
+  report_date: string;
+  region: string;
+  time_slot: 'morning' | 'lunch' | 'evening';
+  scheduled_time: string | null;
+  caption: string;
+  hashtags: string[];
+  referenced_places: string[];
+  status: 'draft' | 'approved' | 'published' | 'rejected';
+  editor_note: string;
+  generated_at: string;
+  approved_at: string | null;
+  published_at: string | null;
+}
+
+export interface DailyTrendReport {
+  id: string;
+  report_date: string;
+  region: string;
+  total_posts_analyzed: number;
+  places: PlaceTrend[];
+  tone_analysis: ToneAnalysis;
+  top_keywords: KeywordTrend[];
+  platforms: { instagram: number; threads: number };
+  created_at: string;
+}
+
+export interface PlaceTrend {
+  name: string;
+  category: string;
+  mention_count: number;
+  confidence: number;
+}
+
+export interface ToneAnalysis {
+  dominant_tone: string;
+  tone_distribution: Record<string, number>;
+  trending_expressions: string[];
+  emoji_trends: string[];
+}
+
+export interface KeywordTrend {
+  keyword: string;
+  count: number;
+  related_hashtags: string[];
+}
+
+// ── 대시보드 통계 ──────────────────────────────────────────
+
+export async function getContentEngineStats() {
+  const supabase = await createServerSupabase();
+
+  const [
+    { count: totalDrafts },
+    { count: pendingDrafts },
+    { count: approvedDrafts },
+    { count: publishedDrafts },
+    { count: totalReports },
+    { count: totalSnsPosts },
+  ] = await Promise.all([
+    supabase.from('generated_drafts').select('*', { count: 'exact', head: true }),
+    supabase.from('generated_drafts').select('*', { count: 'exact', head: true }).eq('status', 'draft'),
+    supabase.from('generated_drafts').select('*', { count: 'exact', head: true }).eq('status', 'approved'),
+    supabase.from('generated_drafts').select('*', { count: 'exact', head: true }).eq('status', 'published'),
+    supabase.from('daily_trend_reports').select('*', { count: 'exact', head: true }),
+    supabase.from('raw_sns_posts').select('*', { count: 'exact', head: true }),
+  ]);
+
+  // 최근 7일 리포트
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  const { data: recentReports } = await supabase
+    .from('daily_trend_reports')
+    .select('report_date, region, total_posts_analyzed, created_at')
+    .gte('report_date', sevenDaysAgo.toISOString().split('T')[0])
+    .order('report_date', { ascending: false })
+    .limit(7);
+
+  // 최근 초안 5개
+  const { data: recentDrafts } = await supabase
+    .from('generated_drafts')
+    .select('*')
+    .order('generated_at', { ascending: false })
+    .limit(5);
+
+  return {
+    totalDrafts: totalDrafts ?? 0,
+    pendingDrafts: pendingDrafts ?? 0,
+    approvedDrafts: approvedDrafts ?? 0,
+    publishedDrafts: publishedDrafts ?? 0,
+    totalReports: totalReports ?? 0,
+    totalSnsPosts: totalSnsPosts ?? 0,
+    recentReports: (recentReports ?? []) as Pick<DailyTrendReport, 'report_date' | 'region' | 'total_posts_analyzed' | 'created_at'>[],
+    recentDrafts: (recentDrafts ?? []) as GeneratedDraft[],
+  };
+}
+
+// ── 초안 목록 ──────────────────────────────────────────────
+
+export async function getDrafts(filters?: {
+  status?: string;
+  region?: string;
+  limit?: number;
+  offset?: number;
+}) {
+  const supabase = await createServerSupabase();
+  const limit = filters?.limit ?? 30;
+  const offset = filters?.offset ?? 0;
+
+  let query = supabase
+    .from('generated_drafts')
+    .select('*', { count: 'exact' })
+    .order('report_date', { ascending: false })
+    .order('time_slot', { ascending: true })
+    .range(offset, offset + limit - 1);
+
+  if (filters?.status) {
+    query = query.eq('status', filters.status);
+  }
+  if (filters?.region) {
+    query = query.eq('region', filters.region);
+  }
+
+  const { data, count, error } = await query;
+  if (error) {
+    console.error('[content-engine] getDrafts error:', error.message);
+    return { drafts: [], total: 0 };
+  }
+
+  return {
+    drafts: (data ?? []) as GeneratedDraft[],
+    total: count ?? 0,
+  };
+}
+
+// ── 초안 상태 변경 ─────────────────────────────────────────
+
+export async function updateDraftStatus(
+  id: string,
+  status: 'approved' | 'published' | 'rejected',
+  editorNote?: string,
+) {
+  const supabase = await createServerSupabase();
+  const updates: Record<string, unknown> = { status };
+
+  if (status === 'approved') updates.approved_at = new Date().toISOString();
+  if (status === 'published') updates.published_at = new Date().toISOString();
+  if (editorNote !== undefined) updates.editor_note = editorNote;
+
+  const { error } = await supabase
+    .from('generated_drafts')
+    .update(updates)
+    .eq('id', id);
+
+  if (error) {
+    console.error('[content-engine] updateDraftStatus error:', error.message);
+    throw error;
+  }
+}
+
+// ── 초안 캡션 수정 ─────────────────────────────────────────
+
+export async function updateDraftCaption(id: string, caption: string) {
+  const supabase = await createServerSupabase();
+  const { error } = await supabase
+    .from('generated_drafts')
+    .update({ caption })
+    .eq('id', id);
+
+  if (error) {
+    console.error('[content-engine] updateDraftCaption error:', error.message);
+    throw error;
+  }
+}
+
+// ── 트렌드 리포트 목록 ────────────────────────────────────
+
+export async function getTrendReports(filters?: {
+  region?: string;
+  limit?: number;
+  offset?: number;
+}) {
+  const supabase = await createServerSupabase();
+  const limit = filters?.limit ?? 14;
+  const offset = filters?.offset ?? 0;
+
+  let query = supabase
+    .from('daily_trend_reports')
+    .select('*', { count: 'exact' })
+    .order('report_date', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (filters?.region) {
+    query = query.eq('region', filters.region);
+  }
+
+  const { data, count, error } = await query;
+  if (error) {
+    console.error('[content-engine] getTrendReports error:', error.message);
+    return { reports: [], total: 0 };
+  }
+
+  return {
+    reports: (data ?? []) as DailyTrendReport[],
+    total: count ?? 0,
+  };
+}
+
+// ── 단일 트렌드 리포트 ────────────────────────────────────
+
+export async function getTrendReport(id: string) {
+  const supabase = await createServerSupabase();
+  const { data, error } = await supabase
+    .from('daily_trend_reports')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) return null;
+  return data as DailyTrendReport;
+}

--- a/admin/supabase/migrations/013_auto_engine_tables.sql
+++ b/admin/supabase/migrations/013_auto_engine_tables.sql
@@ -1,0 +1,231 @@
+-- ============================================================
+-- 013: jwm-auto-engine 연동 테이블
+--
+-- SNS 수집 → 트렌드 분석 → 콘텐츠 자동 생성 파이프라인용
+-- jwm-auto-engine (service_role)에서 쓰기, admin에서 조회/관리
+-- ============================================================
+
+-- ────────────────────────────────────────────────────────────
+-- 1. raw_sns_posts: 수집된 SNS 원본 게시물
+-- ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS raw_sns_posts (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  platform      text NOT NULL CHECK (platform IN ('instagram', 'threads')),
+  author_handle text NOT NULL DEFAULT '',
+  content       text NOT NULL DEFAULT '',
+  hashtags      text[] DEFAULT '{}',
+  media_urls    text[] DEFAULT '{}',
+  region        text NOT NULL DEFAULT '',
+  posted_at     timestamptz NOT NULL DEFAULT now(),
+  collected_at  timestamptz NOT NULL DEFAULT now(),
+  raw_json      jsonb DEFAULT '{}'::jsonb,
+  created_at    timestamptz DEFAULT now(),
+
+  -- 동일 게시물 중복 방지
+  UNIQUE (platform, author_handle, posted_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_raw_sns_posts_platform
+  ON raw_sns_posts(platform);
+CREATE INDEX IF NOT EXISTS idx_raw_sns_posts_region
+  ON raw_sns_posts(region);
+CREATE INDEX IF NOT EXISTS idx_raw_sns_posts_posted_at
+  ON raw_sns_posts(posted_at DESC);
+CREATE INDEX IF NOT EXISTS idx_raw_sns_posts_hashtags_gin
+  ON raw_sns_posts USING GIN (hashtags);
+
+ALTER TABLE raw_sns_posts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS raw_sns_posts_select_all ON raw_sns_posts;
+CREATE POLICY raw_sns_posts_select_all
+  ON raw_sns_posts FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS raw_sns_posts_insert_all ON raw_sns_posts;
+CREATE POLICY raw_sns_posts_insert_all
+  ON raw_sns_posts FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS raw_sns_posts_update_all ON raw_sns_posts;
+CREATE POLICY raw_sns_posts_update_all
+  ON raw_sns_posts FOR UPDATE
+  TO anon, authenticated
+  USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS raw_sns_posts_delete_all ON raw_sns_posts;
+CREATE POLICY raw_sns_posts_delete_all
+  ON raw_sns_posts FOR DELETE
+  TO anon, authenticated
+  USING (true);
+
+
+-- ────────────────────────────────────────────────────────────
+-- 2. place_candidates: 추출된 장소 후보
+-- ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS place_candidates (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name            text NOT NULL,
+  category        text NOT NULL DEFAULT 'other'
+                    CHECK (category IN ('cafe', 'restaurant', 'bar', 'shop', 'gallery', 'other')),
+  region          text NOT NULL DEFAULT '',
+  mention_count   integer DEFAULT 0,
+  sample_contexts text[] DEFAULT '{}',
+  confidence      double precision DEFAULT 0.0
+                    CHECK (confidence >= 0.0 AND confidence <= 1.0),
+  source_date     date NOT NULL DEFAULT CURRENT_DATE,
+  -- locations 테이블과 매칭된 경우 연결 (nullable)
+  matched_location_id uuid DEFAULT NULL,
+  status          text NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending', 'matched', 'ignored', 'new_place')),
+  created_at      timestamptz DEFAULT now(),
+
+  UNIQUE (name, region, source_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_place_candidates_region
+  ON place_candidates(region);
+CREATE INDEX IF NOT EXISTS idx_place_candidates_status
+  ON place_candidates(status);
+CREATE INDEX IF NOT EXISTS idx_place_candidates_source_date
+  ON place_candidates(source_date DESC);
+CREATE INDEX IF NOT EXISTS idx_place_candidates_confidence
+  ON place_candidates(confidence DESC);
+
+ALTER TABLE place_candidates ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS place_candidates_select_all ON place_candidates;
+CREATE POLICY place_candidates_select_all
+  ON place_candidates FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS place_candidates_insert_all ON place_candidates;
+CREATE POLICY place_candidates_insert_all
+  ON place_candidates FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS place_candidates_update_all ON place_candidates;
+CREATE POLICY place_candidates_update_all
+  ON place_candidates FOR UPDATE
+  TO anon, authenticated
+  USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS place_candidates_delete_all ON place_candidates;
+CREATE POLICY place_candidates_delete_all
+  ON place_candidates FOR DELETE
+  TO anon, authenticated
+  USING (true);
+
+
+-- ────────────────────────────────────────────────────────────
+-- 3. daily_trend_reports: 일별 트렌드 분석 리포트
+-- ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS daily_trend_reports (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_date           date NOT NULL,
+  region                text NOT NULL DEFAULT '',
+  total_posts_analyzed  integer DEFAULT 0,
+  places                jsonb DEFAULT '[]'::jsonb,
+  tone_analysis         jsonb DEFAULT '{}'::jsonb,
+  top_keywords          jsonb DEFAULT '[]'::jsonb,
+  platforms             jsonb DEFAULT '{}'::jsonb,
+  created_at            timestamptz DEFAULT now(),
+
+  -- 지역+날짜 기준 하나의 리포트만 존재
+  UNIQUE (report_date, region)
+);
+
+CREATE INDEX IF NOT EXISTS idx_daily_trend_reports_date
+  ON daily_trend_reports(report_date DESC);
+CREATE INDEX IF NOT EXISTS idx_daily_trend_reports_region
+  ON daily_trend_reports(region);
+
+ALTER TABLE daily_trend_reports ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS daily_trend_reports_select_all ON daily_trend_reports;
+CREATE POLICY daily_trend_reports_select_all
+  ON daily_trend_reports FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS daily_trend_reports_insert_all ON daily_trend_reports;
+CREATE POLICY daily_trend_reports_insert_all
+  ON daily_trend_reports FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS daily_trend_reports_update_all ON daily_trend_reports;
+CREATE POLICY daily_trend_reports_update_all
+  ON daily_trend_reports FOR UPDATE
+  TO anon, authenticated
+  USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS daily_trend_reports_delete_all ON daily_trend_reports;
+CREATE POLICY daily_trend_reports_delete_all
+  ON daily_trend_reports FOR DELETE
+  TO anon, authenticated
+  USING (true);
+
+
+-- ────────────────────────────────────────────────────────────
+-- 4. generated_drafts: 생성된 콘텐츠 초안
+-- ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS generated_drafts (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_date       date NOT NULL,
+  region            text NOT NULL DEFAULT '',
+  time_slot         text NOT NULL
+                      CHECK (time_slot IN ('morning', 'lunch', 'evening')),
+  scheduled_time    timestamptz,
+  caption           text NOT NULL DEFAULT '',
+  hashtags          text[] DEFAULT '{}',
+  referenced_places text[] DEFAULT '{}',
+  status            text NOT NULL DEFAULT 'draft'
+                      CHECK (status IN ('draft', 'approved', 'published', 'rejected')),
+  editor_note       text DEFAULT '',
+  generated_at      timestamptz DEFAULT now(),
+  approved_at       timestamptz,
+  published_at      timestamptz,
+  created_at        timestamptz DEFAULT now(),
+
+  -- 날짜+지역+시간대 기준 하나의 초안만 존재
+  UNIQUE (report_date, region, time_slot)
+);
+
+CREATE INDEX IF NOT EXISTS idx_generated_drafts_date
+  ON generated_drafts(report_date DESC);
+CREATE INDEX IF NOT EXISTS idx_generated_drafts_status
+  ON generated_drafts(status);
+CREATE INDEX IF NOT EXISTS idx_generated_drafts_region
+  ON generated_drafts(region);
+CREATE INDEX IF NOT EXISTS idx_generated_drafts_hashtags_gin
+  ON generated_drafts USING GIN (hashtags);
+
+ALTER TABLE generated_drafts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS generated_drafts_select_all ON generated_drafts;
+CREATE POLICY generated_drafts_select_all
+  ON generated_drafts FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS generated_drafts_insert_all ON generated_drafts;
+CREATE POLICY generated_drafts_insert_all
+  ON generated_drafts FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS generated_drafts_update_all ON generated_drafts;
+CREATE POLICY generated_drafts_update_all
+  ON generated_drafts FOR UPDATE
+  TO anon, authenticated
+  USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS generated_drafts_delete_all ON generated_drafts;
+CREATE POLICY generated_drafts_delete_all
+  ON generated_drafts FOR DELETE
+  TO anon, authenticated
+  USING (true);


### PR DESCRIPTION
## 관련 이슈

Closes #5

## 변경 사항

jwm-auto-engine(별도 private 레포)이 자동 생성한 콘텐츠를 admin에서 관리할 수 있는 페이지를 추가했습니다.

- `/content-engine` 대시보드: 전체 통계 + 최근 초안/리포트 미리보기
- `/content-engine/drafts` 초안 관리: 상태별 필터링, 승인/발행/반려 워크플로우
- `/content-engine/trends` 트렌드 리포트: 인기 장소, 키워드, 톤 분석 뷰
- Sidebar 메뉴 추가 (콘텐츠 엔진)
- DB 마이그레이션 013: `raw_sns_posts`, `place_candidates`, `daily_trend_reports`, `generated_drafts`

## 변경 유형

- [x] 새로운 기능 (`feat`)
- [x] 빌드/설정 변경 (`chore`)

## 구현 상세

### 초안 워크플로우
```
engine 자동 생성 (draft) → admin 승인 (approved) → 발행 (published)
                         └→ 반려 (rejected) → 재승인 가능
```

### 파일 구조
```
admin/src/
├── app/content-engine/
│   ├── page.tsx              # 대시보드
│   ├── actions.ts            # Server Actions (승인/발행/반려)
│   ├── drafts/
│   │   ├── page.tsx          # 초안 목록 + 필터
│   │   └── DraftActions.tsx  # 액션 버튼 (Client)
│   └── trends/
│       └── page.tsx          # 트렌드 리포트
├── lib/queries/
│   └── content-engine.ts     # Supabase 쿼리
└── components/layout/
    └── Sidebar.tsx           # 메뉴 추가
```

### 연동 구조
- **jwm-auto-engine** → `service_role` 키로 DB에 쓰기 (초안 생성, 트렌드 저장)
- **JWMAP admin** → SSR 클라이언트로 DB 읽기/상태 업데이트 (승인, 발행)

## 테스트

- [x] 로컬 빌드 (`next build`) 통과
- [x] 3개 라우트 정상 등록 확인

## 참고사항

- DB 테이블은 Supabase SQL Editor에서 `013_auto_engine_tables.sql` 실행 필요
- jwm-auto-engine 레포: https://github.com/JJongW/jmw-auto-engine (PR #2)