### PR TITLE
fix(api): Vercel 빌드 오류 수정

### DIFF
--- a/project/api/search.ts
+++ b/project/api/search.ts
@@ -1,31 +1,31 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { randomUUID } from 'crypto';
-import { runFallbackSearch } from './searchFallback';
-import { generateSearchActions, generateUIHints } from './searchPresentation';
-import { parseEnhancedQuery, toLegacyQuery } from './searchParser';
-import { updateSearchLogParsed, updateSearchLogResult } from './searchLogging';
+import { runFallbackSearch } from './searchFallback.js';
+import { generateSearchActions, generateUIHints } from './searchPresentation.js';
+import { parseEnhancedQuery, toLegacyQuery } from './searchParser.js';
+import { updateSearchLogParsed, updateSearchLogResult } from './searchLogging.js';
 import {
   fetchLocationsSearchRows,
   fetchTagMatchedLocationIds,
   fetchTopRatedLocations as fetchTopRatedFromRepo,
-} from './searchRepository';
+} from './searchRepository.js';
 import {
   applyConstraintFilter,
   applyKeywordFilter,
   applyLocationKeywordFilter,
-} from './searchRanker';
+} from './searchRanker.js';
 import {
   expandKeywordsForTagSearch,
   inferConstraintFlagsFromKeywords,
-} from './tagIntelligence';
+} from './tagIntelligence.js';
 import type {
   EnhancedLLMQuery,
   FallbackResult,
   LLMQuery,
   Location,
   TimingMetrics,
-} from './searchTypes';
+} from './searchTypes.js';
 type CourseRecommendation = {
   title: string;
   themeTags: string[];

--- a/project/api/searchFallback.ts
+++ b/project/api/searchFallback.ts
@@ -1,4 +1,4 @@
-import type { EnhancedLLMQuery, FallbackResult, LLMQuery, Location, SearchConstraint } from './searchTypes';
+import type { EnhancedLLMQuery, FallbackResult, LLMQuery, Location, SearchConstraint } from './searchTypes.js';
 
 type LegacyQueryBuilder = (enhanced: EnhancedLLMQuery, uiRegion?: string) => LLMQuery;
 type SearchExecutor = (query: LLMQuery) => Promise<Location[]>;

--- a/project/api/searchLogging.ts
+++ b/project/api/searchLogging.ts
@@ -1,4 +1,4 @@
-import type { EnhancedLLMQuery } from './searchTypes';
+import type { EnhancedLLMQuery } from './searchTypes.js';
 
 type SearchLogsUpdater = {
   from: (table: string) => {

--- a/project/api/searchParser.ts
+++ b/project/api/searchParser.ts
@@ -1,10 +1,10 @@
 import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 import { HumanMessage } from '@langchain/core/messages';
-import type { EnhancedLLMQuery, LLMQuery, SearchIntent, TimeOfDay, VisitContext } from './searchTypes';
+import type { EnhancedLLMQuery, LLMQuery, SearchIntent, TimeOfDay, VisitContext } from './searchTypes.js';
 import {
   inferConstraintFlagsFromKeywords,
   sanitizeTagNames,
-} from './tagIntelligence';
+} from './tagIntelligence.js';
 
 const llm = new ChatGoogleGenerativeAI({
   model: 'gemini-2.0-flash',

--- a/project/api/searchPresentation.ts
+++ b/project/api/searchPresentation.ts
@@ -1,4 +1,4 @@
-import type { EnhancedLLMQuery, FallbackResult, SearchActions, UIHints } from './searchTypes';
+import type { EnhancedLLMQuery, FallbackResult, SearchActions, UIHints } from './searchTypes.js';
 
 export function generateUIHints(
   enhanced: EnhancedLLMQuery,

--- a/project/api/searchRanker.ts
+++ b/project/api/searchRanker.ts
@@ -1,5 +1,5 @@
-import type { LLMQuery, Location } from './searchTypes';
-import type { SearchCandidate } from './searchRepository';
+import type { LLMQuery, Location } from './searchTypes.js';
+import type { SearchCandidate } from './searchRepository.js';
 
 function locationMatchesKeyword(
   loc: { subRegion?: string; region?: string; province?: string; tags?: string[] },

--- a/project/api/searchRepository.ts
+++ b/project/api/searchRepository.ts
@@ -1,4 +1,4 @@
-import type { LLMQuery, Location } from './searchTypes';
+import type { LLMQuery, Location } from './searchTypes.js';
 
 type SupabaseLike = {
   from: (table: string) => {
@@ -121,7 +121,7 @@ export async function fetchTopRatedLocations(getSupabase: GetSupabase): Promise<
   const { data } = await getSupabase()
     .from('locations')
     .select('*')
-    .order('rating', { ascending: false })
+    .order('rating', { ascending: false, nullsFirst: false })
     .limit(20);
   return (data || []).map((item: Record<string, unknown>) => mapDbRowToLocation(item));
 }

--- a/project/api/suggest-tags.ts
+++ b/project/api/suggest-tags.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import {
   sanitizeTagNames,
   sanitizeTagSuggestions,
-} from './tagIntelligence';
+} from './tagIntelligence.js';
 
 // Zod 스키마 정의 (API 서버용)
 const TagSuggestionSchema = z.object({


### PR DESCRIPTION
## Summary
- `project/api/` 내 상대 경로 import에 `.js` 확장자 추가 (Vercel `node16` moduleResolution 대응)
- `searchRepository.ts`의 `.order()` 호출에 누락된 `nullsFirst: false` 파라미터 추가

## 관련 이슈
- PR #6 머지 시 누락된 커밋 반영

## Test plan
- [x] Vercel 프리뷰 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)