### PR TITLE
fix(admin): stabilize course input and improve location insert diagnostics

### DIFF
--- a/admin/src/components/courses/CourseBuilder.tsx
+++ b/admin/src/components/courses/CourseBuilder.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 
 interface DraftPlace {
+  id: string;
   name: string;
   note: string;
 }
@@ -30,9 +31,9 @@ export function CourseBuilder({ initialCourses }: { initialCourses: SavedCourseR
   const [courseTitle, setCourseTitle] = useState('');
   const [regionHint, setRegionHint] = useState('');
   const [places, setPlaces] = useState<DraftPlace[]>([
-    { name: '', note: '' },
-    { name: '', note: '' },
-    { name: '', note: '' },
+    { id: crypto.randomUUID(), name: '', note: '' },
+    { id: crypto.randomUUID(), name: '', note: '' },
+    { id: crypto.randomUUID(), name: '', note: '' },
   ]);
   const [isSaving, setIsSaving] = useState(false);
   const [savedCourses, setSavedCourses] = useState<SavedCourseRow[]>(initialCourses);
@@ -42,7 +43,7 @@ export function CourseBuilder({ initialCourses }: { initialCourses: SavedCourseR
   }
 
   function addPlace() {
-    setPlaces((prev) => [...prev, { name: '', note: '' }]);
+    setPlaces((prev) => [...prev, { id: crypto.randomUUID(), name: '', note: '' }]);
   }
 
   function removePlace(index: number) {
@@ -123,7 +124,7 @@ export function CourseBuilder({ initialCourses }: { initialCourses: SavedCourseR
 
           <div className="space-y-3">
             {places.map((place, index) => (
-              <div key={`${index}-${place.name}`} className="rounded-lg border p-3 space-y-2">
+              <div key={place.id} className="rounded-lg border p-3 space-y-2">
                 <div className="flex items-center gap-2">
                   <Input
                     placeholder={`장소명 ${index + 1}`}

--- a/admin/src/lib/supabase/service.ts
+++ b/admin/src/lib/supabase/service.ts
@@ -1,12 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
 
 export function createServiceSupabase() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+  const key = (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY)?.trim();
 
   if (!url || !key) {
-    throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+    throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY/SUPABASE_SERVICE_KEY');
   }
 
+  // Trim keys to avoid subtle failures when copied with whitespace in .env files.
   return createClient(url, key);
 }


### PR DESCRIPTION
## 변경사항
- 코스 수동 등록에서 장소명 입력 칸이 1글자 입력 후 멈추는 이슈를 수정
  - 장소 목록 렌더 key를 name 기반에서 고정 id 기반으로 변경
- Supabase/카카오/구글 API 키 처리 강화
  - .env 값의 공백을 trim() 처리
- 장소 insert/update 실패 진단 강화
  - Invalid API key 같은 인증 이슈에 대해 원인 힌트를 에러 메시지에 반영

## 테스트
- vitest: admin/src/app/api/courses/build/helpers.test.ts 통과