### PR TITLE
fix: 검색 로그 미기록 문제 수정

### DIFF
--- a/odiga/src/index.ts
+++ b/odiga/src/index.ts
@@ -249,17 +249,6 @@ async function runSingleMode(
     }
 
     renderPlaceDetail(selected);
-
-    logSilent({
-      rawQuery,
-      intent: response.intent,
-      mode: 'single',
-      parseErrors: response.parseErrors,
-      selectedPlaceId: selected.place.id,
-      selectedPlaceName: selected.place.name,
-      regenerateCount,
-      userFeedbacks: feedbacks,
-    });
     return { type: 'done' };
   }
 }
@@ -353,15 +342,6 @@ async function runCourseMode(
     }
   }
 
-  logSilent({
-    rawQuery,
-    intent: response.intent,
-    mode: selectedCourse!.mode,
-    parseErrors: response.parseErrors,
-    selectedCourse,
-    regenerateCount,
-    userFeedbacks: feedbacks,
-  });
   return { type: 'done' };
 }
 
@@ -450,6 +430,13 @@ async function runSearch(rawQuery: string): Promise<FlowAction> {
     console.log(c.warn('  지역 정보를 확인할 수 없어요. 지역을 더 구체적으로 입력해주세요.'));
     return { type: 'done' };
   }
+
+  logSilent({
+    rawQuery: query,
+    intent: response.intent,
+    mode: response.intent.mode || (response.type === 'course' ? 'course' : 'single'),
+    parseErrors: response.parseErrors,
+  });
 
   console.log(c.dim(`  ${response.type === 'course' ? '코스' : '장소'} 추천 | 지역: ${response.intent.region} | 시즌: ${response.intent.season}`));
   console.log(c.dim(`  오늘오디가의 요약: ${response.curated_summary}`));

--- a/odiga/supabase/migrations/20260221_01_add_user_feedbacks.sql
+++ b/odiga/supabase/migrations/20260221_01_add_user_feedbacks.sql
@@ -1,0 +1,3 @@
+-- odiga: user_feedbacks 컬럼 추가 (log.ts에서 이미 사용 중이나 스키마에 누락됨)
+ALTER TABLE odiga_search_logs
+  ADD COLUMN IF NOT EXISTS user_feedbacks text[] DEFAULT '{}';


### PR DESCRIPTION
Closes #21

## 변경 사항

### 1. Migration: `user_feedbacks` 컬럼 추가
`log.ts`가 항상 `user_feedbacks: []`를 포함해서 INSERT하지만 스키마에 해당 컬럼이 없어 모든 로그 INSERT가 실패하고 있었음. `.catch(() => {})` 패턴으로 무음 처리되어 발견이 늦어짐.

### 2. logSilent() 호출 시점 이동
기존에는 유저가 특정 장소/코스를 선택한 후에만 로그를 기록했음. 검색 자체를 기록해야 하므로 `runSearch()` 응답 직후로 이동.

## 테스트 체크리스트
- [ ] 마이그레이션 실행 후 검색 시 로그 기록 확인
- [ ] 장소 선택 없이 종료해도 로그 남는지 확인
- [ ] 코스 모드에서도 동일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)