### PR TITLE
feat: Odiga Quality Control Console 추가

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -28,6 +28,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.1",
+    "recharts": "^3.7.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.3.6"

--- a/admin/src/app/odiga-quality/loading.tsx
+++ b/admin/src/app/odiga-quality/loading.tsx
@@ -1,0 +1,78 @@
+import { AdminLayout } from '@/components/layout/AdminLayout';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+
+function Skeleton({ className }: { className?: string }) {
+  return <div className={`animate-pulse rounded bg-muted ${className ?? ''}`} />;
+}
+
+function SkeletonCard({ rows = 3 }: { rows?: number }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-3 w-64 mt-1" />
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3 pt-2">
+          {Array.from({ length: rows }).map((_, i) => (
+            <Skeleton key={i} className="h-6 w-full" />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function OdigaQualityLoading() {
+  return (
+    <AdminLayout>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-4 w-40" />
+        </div>
+
+        {/* Filter bar skeleton */}
+        <div className="flex gap-3 py-3 border-b mb-2">
+          {[28, 32, 28].map((w, i) => (
+            <Skeleton key={i} className={`h-8 w-${w}`} />
+          ))}
+        </div>
+
+        {/* Hero skeleton */}
+        <Card className="p-6">
+          <div className="flex flex-col md:flex-row gap-6">
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-3 w-32" />
+              <Skeleton className="h-20 w-36" />
+              <Skeleton className="h-3 w-20" />
+            </div>
+            <div className="flex flex-wrap gap-3 flex-1">
+              {[1, 2, 3, 4].map((i) => (
+                <Skeleton key={i} className="h-24 w-36 rounded-lg" />
+              ))}
+            </div>
+          </div>
+        </Card>
+
+        {/* Row 1 */}
+        <div className="grid gap-4 md:grid-cols-2">
+          <SkeletonCard rows={4} />
+          <SkeletonCard rows={3} />
+        </div>
+
+        {/* Intent table */}
+        <SkeletonCard rows={5} />
+
+        {/* Row 2 */}
+        <div className="grid gap-4 md:grid-cols-2">
+          <SkeletonCard rows={4} />
+          <SkeletonCard rows={4} />
+        </div>
+
+        {/* DB Pressure */}
+        <SkeletonCard rows={6} />
+      </div>
+    </AdminLayout>
+  );
+}

--- a/admin/src/app/odiga-quality/page.tsx
+++ b/admin/src/app/odiga-quality/page.tsx
@@ -1,0 +1,71 @@
+import { AdminLayout } from '@/components/layout/AdminLayout';
+import { FilterBar } from '@/components/odiga-quality/FilterBar';
+import { HeroSection } from '@/components/odiga-quality/HeroSection';
+import { FirstMatchCard } from '@/components/odiga-quality/FirstMatchCard';
+import { TrustEngagementCard } from '@/components/odiga-quality/TrustEngagementCard';
+import { IntentMatchTable } from '@/components/odiga-quality/IntentMatchTable';
+import { CourseQualityCard } from '@/components/odiga-quality/CourseQualityCard';
+import { FrictionScoreCard } from '@/components/odiga-quality/FrictionScoreCard';
+import { DBPressureTable } from '@/components/odiga-quality/DBPressureTable';
+import { AlertPanel } from '@/components/odiga-quality/AlertPanel';
+import { getQualityData, parseFilters } from '@/lib/queries/odiga-quality';
+
+interface PageProps {
+  searchParams: Promise<{
+    period?: string;
+    region?: string;
+    response_type?: string;
+    activity_type?: string;
+  }>;
+}
+
+export default async function OdigaQualityPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const filters = parseFilters(params);
+  const data = await getQualityData(filters);
+
+  return (
+    <AdminLayout>
+      <div className="space-y-5">
+        <div className="flex items-center justify-between">
+          <h1 className="text-xl font-bold tracking-tight">Quality Console</h1>
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {data.dateRange.from.slice(0, 10)} ~ {data.dateRange.to.slice(0, 10)}
+          </span>
+        </div>
+
+        {/* Sticky Filter Bar */}
+        <FilterBar
+          period={filters.period}
+          region={filters.region}
+          response_type={filters.response_type}
+          activity_type={filters.activity_type}
+        />
+
+        {/* OQS Hero */}
+        <HeroSection oqs={data.oqs} totalSearches={data.totalSearches} />
+
+        {/* Row 1: First Match + Trust */}
+        <div className="grid gap-4 md:grid-cols-2">
+          <FirstMatchCard data={data.firstMatch} />
+          <TrustEngagementCard data={data.trust} />
+        </div>
+
+        {/* Intent Match Table (full width) */}
+        <IntentMatchTable rows={data.intents} />
+
+        {/* Row 2: Course Quality + Friction */}
+        <div className="grid gap-4 md:grid-cols-2">
+          <CourseQualityCard data={data.course} />
+          <FrictionScoreCard data={data.friction} />
+        </div>
+
+        {/* DB Pressure (full width) */}
+        <DBPressureTable rows={data.dbPressure} />
+      </div>
+
+      {/* Alert Panel (fixed, client component) */}
+      <AlertPanel alerts={data.alerts} />
+    </AdminLayout>
+  );
+}

--- a/admin/src/components/layout/Sidebar.tsx
+++ b/admin/src/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, MapPin, AlertTriangle, Sparkles, Route, Bot, Cpu } from 'lucide-react';
+import { LayoutDashboard, MapPin, AlertTriangle, Sparkles, Route, Bot, Cpu, BarChart2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const navItems = [
@@ -11,6 +11,7 @@ const navItems = [
   { href: '/attractions', label: '볼거리 관리', icon: Sparkles },
   { href: '/courses', label: '코스 관리', icon: Route },
   { href: '/locations/incomplete', label: '데이터 품질', icon: AlertTriangle },
+  { href: '/odiga-quality', label: 'Quality Console', icon: BarChart2 },
   { href: '/content-engine', label: '콘텐츠 엔진', icon: Bot },
   { href: '/automation', label: 'Automation', icon: Cpu },
 ];

--- a/admin/src/components/odiga-quality/AlertPanel.tsx
+++ b/admin/src/components/odiga-quality/AlertPanel.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+import { AlertTriangle, XCircle, ChevronDown, ChevronUp, Bell } from 'lucide-react';
+import type { AlertItem } from '@/types/odiga-quality';
+
+interface AlertPanelProps {
+  alerts: AlertItem[];
+}
+
+export function AlertPanel({ alerts }: AlertPanelProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  if (alerts.length === 0) return null;
+
+  const errorCount = alerts.filter((a) => a.type === 'error').length;
+  const warnCount = alerts.filter((a) => a.type === 'warn').length;
+
+  return (
+    <div className="fixed bottom-6 right-6 z-50 w-80 rounded-xl border border-gray-100 shadow-lg bg-white">
+      {/* Header */}
+      <button
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex w-full items-center justify-between px-4 py-3 text-sm font-semibold border-b border-gray-100 rounded-t-xl hover:bg-gray-50 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <Bell className="h-4 w-4 text-orange-500" />
+          <span>알림</span>
+          {errorCount > 0 && (
+            <span className="rounded-full bg-red-50 text-red-600 text-xs px-1.5 py-0.5 font-semibold">
+              {errorCount}
+            </span>
+          )}
+          {warnCount > 0 && (
+            <span className="rounded-full bg-orange-50 text-orange-600 text-xs px-1.5 py-0.5 font-medium">
+              {warnCount}
+            </span>
+          )}
+        </div>
+        {collapsed ? (
+          <ChevronUp className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        )}
+      </button>
+
+      {/* Alert list */}
+      {!collapsed && (
+        <div className="max-h-64 overflow-y-auto divide-y divide-gray-50">
+          {alerts.map((alert, i) => (
+            <div key={i} className="flex items-start gap-3 px-4 py-3">
+              {alert.type === 'error' ? (
+                <XCircle className="h-4 w-4 text-red-500 mt-0.5 shrink-0" />
+              ) : (
+                <AlertTriangle className="h-4 w-4 text-orange-500 mt-0.5 shrink-0" />
+              )}
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <p className="text-xs font-medium leading-snug">{alert.message}</p>
+                <p className="text-xs text-muted-foreground">
+                  {alert.metric}: {alert.value.toFixed(1)} (기준: {alert.threshold})
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin/src/components/odiga-quality/CourseQualityCard.tsx
+++ b/admin/src/components/odiga-quality/CourseQualityCard.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { MetricCard } from './MetricCard';
+import type { CourseMetrics } from '@/types/odiga-quality';
+
+interface CourseQualityCardProps {
+  data: CourseMetrics;
+}
+
+export function CourseQualityCard({ data }: CourseQualityCardProps) {
+  return (
+    <MetricCard
+      title="Course Quality"
+      explanation="큐레이션된 코스의 스토리텔링 효과 평가"
+    >
+      <div className="flex flex-col gap-4">
+        {/* Primary metric */}
+        <div>
+          <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+            코스 선택률
+          </p>
+          <span className="text-5xl font-bold tabular-nums text-orange-500">
+            {data.selectionRate.toFixed(1)}%
+          </span>
+        </div>
+
+        {/* Secondary metrics */}
+        <div className="flex gap-6 text-sm">
+          <div>
+            <p className="text-muted-foreground text-[11px] uppercase tracking-wider font-medium">코스 요청수</p>
+            <p className="font-semibold tabular-nums mt-0.5">{data.requestCount.toLocaleString()}</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground text-[11px] uppercase tracking-wider font-medium">저장률</p>
+            <p className="font-semibold tabular-nums mt-0.5">{data.saveRate.toFixed(1)}%</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground text-[11px] uppercase tracking-wider font-medium">평균 재추천</p>
+            <p className="font-semibold tabular-nums mt-0.5">{data.avgReroll.toFixed(2)}회</p>
+          </div>
+        </div>
+
+        {/* Trend area chart */}
+        {data.selectionTrend.length > 1 ? (
+          <div className="h-28">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={data.selectionTrend}>
+                <defs>
+                  <linearGradient id="orangeAreaGrad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#FF8A3D" stopOpacity={0.15} />
+                    <stop offset="95%" stopColor="#FF8A3D" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <XAxis
+                  dataKey="date"
+                  tick={{ fontSize: 10, fill: '#9CA3AF' }}
+                  axisLine={false}
+                  tickLine={false}
+                  tickFormatter={(v: string) => v.slice(5)}
+                />
+                <YAxis
+                  domain={[0, 100]}
+                  tick={{ fontSize: 10, fill: '#9CA3AF' }}
+                  axisLine={false}
+                  tickLine={false}
+                  tickFormatter={(v: number) => `${v}%`}
+                  width={32}
+                />
+                <Tooltip
+                  formatter={(v) => [v != null ? `${v}%` : '-', '선택률']}
+                  contentStyle={{ fontSize: 12, borderRadius: 8, border: '1px solid #E5E7EB' }}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="rate"
+                  stroke="#FF8A3D"
+                  strokeWidth={2}
+                  fill="url(#orangeAreaGrad)"
+                  dot={{ r: 3, fill: '#FF8A3D', strokeWidth: 0 }}
+                  activeDot={{ r: 5, fill: '#FF8A3D', strokeWidth: 0 }}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        ) : (
+          <p className="text-xs text-muted-foreground">트렌드 표시를 위한 데이터 부족</p>
+        )}
+      </div>
+    </MetricCard>
+  );
+}

--- a/admin/src/components/odiga-quality/DBPressureTable.tsx
+++ b/admin/src/components/odiga-quality/DBPressureTable.tsx
@@ -1,0 +1,101 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import type { DBPressureRow } from '@/types/odiga-quality';
+
+interface DBPressureTableProps {
+  rows: DBPressureRow[];
+}
+
+function PressureBar({ score, status }: { score: number; status: DBPressureRow['status'] }) {
+  const pct = Math.min(100, (score / 6) * 100);
+  const barColor =
+    status === 'ok' ? 'bg-emerald-400' : status === 'warn' ? 'bg-orange-400' : 'bg-red-500';
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 w-20 rounded-full bg-gray-100 overflow-hidden">
+        <div className={cn('h-full rounded-full', barColor)} style={{ width: `${pct}%` }} />
+      </div>
+      <span
+        className={cn(
+          'font-mono text-xs font-semibold tabular-nums',
+          status === 'ok' ? 'text-emerald-700' : status === 'warn' ? 'text-orange-600' : 'text-red-600',
+        )}
+      >
+        {score.toFixed(1)}x
+      </span>
+    </div>
+  );
+}
+
+export function DBPressureTable({ rows }: DBPressureTableProps) {
+  return (
+    <Card className="shadow-sm rounded-xl border-gray-100 bg-white">
+      <div className="px-5 pt-5 pb-3">
+        <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">DB Pressure Heatmap</p>
+        <p className="text-xs text-muted-foreground/70 mt-0.5">
+          지역별 요청 수 / 장소 수 = 압력 지수 — 4.0 이상 시 장소 보강 필요
+        </p>
+      </div>
+      <CardContent className="p-0">
+        {rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">데이터 없음</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow className="border-gray-100 bg-gray-50/60">
+                <TableHead className="pl-5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">지역</TableHead>
+                <TableHead className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">요청수</TableHead>
+                <TableHead className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">장소수</TableHead>
+                <TableHead className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">압력 지수</TableHead>
+                <TableHead className="text-right pr-5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">상태</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow
+                  key={row.region}
+                  className={cn(
+                    'border-gray-100 text-sm hover:bg-gray-50/50',
+                    row.status === 'critical' && 'bg-red-50/50',
+                  )}
+                >
+                  <TableCell className="pl-5 font-medium">{row.region}</TableCell>
+                  <TableCell className="text-right tabular-nums text-muted-foreground">
+                    {row.requestCount.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums text-muted-foreground">
+                    {row.placeCount.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end">
+                      <PressureBar score={row.pressureScore} status={row.status} />
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right pr-5">
+                    <span
+                      className={cn(
+                        'text-xs font-medium',
+                        row.status === 'ok' ? 'text-emerald-700' : row.status === 'warn' ? 'text-orange-600' : 'text-red-600',
+                      )}
+                    >
+                      {row.status === 'ok' ? '정상' : row.status === 'warn' ? '주의' : '위험'}
+                    </span>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin/src/components/odiga-quality/FilterBar.tsx
+++ b/admin/src/components/odiga-quality/FilterBar.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+import { useCallback } from 'react';
+import { cn } from '@/lib/utils';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const PERIODS = [
+  { value: '1d', label: '오늘' },
+  { value: '7d', label: '7일' },
+  { value: '30d', label: '30일' },
+];
+
+const RESPONSE_TYPES = [
+  { value: 'all', label: '전체' },
+  { value: 'single', label: '장소 추천' },
+  { value: 'course', label: '코스 추천' },
+];
+
+const ACTIVITY_TYPES = [
+  { value: 'all', label: '전체' },
+  { value: '맛집', label: '맛집' },
+  { value: '카페', label: '카페' },
+  { value: '볼거리', label: '볼거리' },
+  { value: '기타', label: '기타' },
+];
+
+interface FilterBarProps {
+  period: string;
+  region: string | null;
+  response_type: string;
+  activity_type: string | null;
+}
+
+export function FilterBar({ period, region, response_type, activity_type }: FilterBarProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const setParam = useCallback(
+    (key: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value === 'all' || value === '') {
+        params.delete(key);
+      } else {
+        params.set(key, value);
+      }
+      router.push(`${pathname}?${params.toString()}`);
+    },
+    [router, pathname, searchParams],
+  );
+
+  return (
+    <div className="sticky top-0 z-10 flex flex-wrap items-center gap-2 border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80 px-1 py-3 mb-5">
+      {/* Period pills */}
+      <div className="flex items-center rounded-lg border bg-gray-50 p-0.5 gap-0.5">
+        {PERIODS.map((p) => (
+          <button
+            key={p.value}
+            onClick={() => setParam('period', p.value)}
+            className={cn(
+              'h-7 rounded-md px-3 text-xs font-medium transition-all',
+              period === p.value
+                ? 'bg-orange-500 text-white shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      <Select value={response_type} onValueChange={(v) => setParam('response_type', v)}>
+        <SelectTrigger className="h-8 w-32 text-xs bg-white">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {RESPONSE_TYPES.map((t) => (
+            <SelectItem key={t.value} value={t.value} className="text-xs">
+              {t.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={activity_type ?? 'all'}
+        onValueChange={(v) => setParam('activity_type', v)}
+      >
+        <SelectTrigger className="h-8 w-28 text-xs bg-white">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {ACTIVITY_TYPES.map((a) => (
+            <SelectItem key={a.value} value={a.value} className="text-xs">
+              {a.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {region && (
+        <button
+          onClick={() => setParam('region', '')}
+          className="flex items-center gap-1 rounded-full border bg-orange-50 border-orange-200 px-2.5 py-1 text-xs text-orange-700 hover:bg-orange-100 transition-colors"
+        >
+          📍 {region}
+          <span className="ml-0.5 opacity-60">✕</span>
+        </button>
+      )}
+
+      <span className="ml-auto text-xs text-muted-foreground font-medium">Quality Console</span>
+    </div>
+  );
+}

--- a/admin/src/components/odiga-quality/FirstMatchCard.tsx
+++ b/admin/src/components/odiga-quality/FirstMatchCard.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+import { MetricCard } from './MetricCard';
+import type { FirstMatchMetrics } from '@/types/odiga-quality';
+
+interface FirstMatchCardProps {
+  data: FirstMatchMetrics;
+}
+
+export function FirstMatchCard({ data }: FirstMatchCardProps) {
+  const chartData = [
+    { label: '0회', count: data.distribution.zero, fill: '#FF8A3D' },
+    { label: '1회', count: data.distribution.one, fill: '#FFBB85' },
+    { label: '2+회', count: data.distribution.twoPlus, fill: '#E5E7EB' },
+  ];
+
+  return (
+    <MetricCard
+      title="First Match Quality"
+      explanation="처음 추천이 사용자를 만족시킨 비율"
+    >
+      <div className="flex flex-col gap-4">
+        {/* Big number */}
+        <div>
+          <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+            재추천 없음
+          </p>
+          <div className="flex items-baseline gap-2">
+            <span className="text-5xl font-bold tabular-nums text-orange-500">
+              {data.zeroRerollRate.toFixed(1)}%
+            </span>
+          </div>
+        </div>
+
+        {/* Secondary metrics */}
+        <div className="flex gap-6 text-sm">
+          <div>
+            <p className="text-muted-foreground text-[11px] uppercase tracking-wider font-medium">첫 결과 선택률</p>
+            <p className="font-semibold tabular-nums mt-0.5">{data.firstSelectRate.toFixed(1)}%</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground text-[11px] uppercase tracking-wider font-medium">평균 재추천</p>
+            <p className="font-semibold tabular-nums mt-0.5">{data.avgRerollCount.toFixed(2)}회</p>
+          </div>
+        </div>
+
+        {/* Bar chart */}
+        <div className="h-28">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData} barSize={36} barCategoryGap="30%">
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 11, fill: '#9CA3AF' }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis hide />
+              <Tooltip
+                formatter={(v) => [v, '세션']}
+                contentStyle={{ fontSize: 12, borderRadius: 8, border: '1px solid #E5E7EB' }}
+                cursor={{ fill: '#F9FAFB' }}
+              />
+              <Bar dataKey="count" radius={[4, 4, 0, 0]}>
+                {chartData.map((entry) => (
+                  <Cell key={entry.label} fill={entry.fill} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </MetricCard>
+  );
+}

--- a/admin/src/components/odiga-quality/FrictionScoreCard.tsx
+++ b/admin/src/components/odiga-quality/FrictionScoreCard.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+import { MetricCard } from './MetricCard';
+import type { FrictionMetrics } from '@/types/odiga-quality';
+
+interface FrictionScoreCardProps {
+  data: FrictionMetrics;
+}
+
+export function FrictionScoreCard({ data }: FrictionScoreCardProps) {
+  const donutData = [
+    { name: '지역 누락', value: Math.round(data.regionMissingRate), fill: '#FF8A3D' },
+    { name: '지역 있음', value: Math.round(100 - data.regionMissingRate), fill: '#F3F4F6' },
+  ];
+
+  return (
+    <MetricCard
+      title="Friction Score"
+      explanation="사용자의 의사결정 마찰과 UX 불편 감지"
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start gap-4">
+          {/* Donut chart */}
+          <div className="h-28 w-28 shrink-0">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={donutData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={28}
+                  outerRadius={48}
+                  startAngle={90}
+                  endAngle={-270}
+                  dataKey="value"
+                  strokeWidth={0}
+                >
+                  {donutData.map((entry) => (
+                    <Cell key={entry.name} fill={entry.fill} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  formatter={(v) => [v != null ? `${v}%` : '-', '']}
+                  contentStyle={{ fontSize: 12, borderRadius: 8, border: '1px solid #E5E7EB' }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+
+          {/* Right side metrics */}
+          <div className="flex flex-col gap-3 flex-1">
+            <div>
+              <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">지역 누락률</p>
+              <p
+                className={`text-xl font-bold tabular-nums mt-0.5 ${data.regionMissingRate > 30 ? 'text-orange-500' : 'text-foreground'}`}
+              >
+                {data.regionMissingRate.toFixed(1)}%
+              </p>
+            </div>
+            <div>
+              <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">미선택 세션율</p>
+              <p className={`text-xl font-bold tabular-nums mt-0.5 ${data.noSelectionRate > 50 ? 'text-amber-500' : 'text-foreground'}`}>
+                {data.noSelectionRate.toFixed(1)}%
+              </p>
+            </div>
+            <div>
+              <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">파싱 오류율</p>
+              <p
+                className={`text-xl font-bold tabular-nums mt-0.5 ${data.parseErrorRate > 20 ? 'text-red-500' : 'text-foreground'}`}
+              >
+                {data.parseErrorRate.toFixed(1)}%
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Parse error breakdown */}
+        {data.parseErrorBreakdown.length > 0 && (
+          <div>
+            <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-2">파싱 오류 필드 분포</p>
+            <div className="space-y-1.5">
+              {data.parseErrorBreakdown.map((item) => (
+                <div key={item.field} className="flex items-center justify-between text-xs">
+                  <span className="font-mono text-muted-foreground">{item.field}</span>
+                  <span className="font-semibold tabular-nums">{item.count}건</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </MetricCard>
+  );
+}

--- a/admin/src/components/odiga-quality/HeroSection.tsx
+++ b/admin/src/components/odiga-quality/HeroSection.tsx
@@ -1,0 +1,111 @@
+import { cn } from '@/lib/utils';
+import type { OQSMetrics } from '@/types/odiga-quality';
+
+interface SubMetric {
+  label: string;
+  value: number;
+  unit: string;
+  explanation: string;
+  higherIsBetter: boolean;
+}
+
+interface HeroSectionProps {
+  oqs: OQSMetrics;
+  totalSearches: number;
+}
+
+function SubMetricCard({ metric }: { metric: SubMetric }) {
+  return (
+    <div className="flex flex-col gap-1.5 rounded-xl border border-orange-100 bg-orange-50/60 px-4 py-3 min-w-[140px]">
+      <span className="text-[10px] font-semibold text-orange-600/80 uppercase tracking-wider">
+        {metric.label}
+      </span>
+      <div className="flex items-baseline gap-1">
+        <span className="text-2xl font-bold tabular-nums text-foreground">
+          {metric.value.toFixed(1)}
+        </span>
+        <span className="text-xs text-muted-foreground">{metric.unit}</span>
+      </div>
+      <span className="text-[11px] text-muted-foreground leading-tight">{metric.explanation}</span>
+    </div>
+  );
+}
+
+export function HeroSection({ oqs, totalSearches }: HeroSectionProps) {
+  const deltaPositive = oqs.delta >= 0;
+
+  const subMetrics: SubMetric[] = [
+    {
+      label: 'First Match Quality',
+      value: oqs.fmq,
+      unit: '%',
+      explanation: '첫 추천으로 만족한 비율',
+      higherIsBetter: true,
+    },
+    {
+      label: 'Trust Index',
+      value: oqs.trustIndex,
+      unit: '%',
+      explanation: '장소/코스를 선택한 비율',
+      higherIsBetter: true,
+    },
+    {
+      label: 'Course Completion',
+      value: oqs.courseCompletion,
+      unit: '%',
+      explanation: '코스 모드 선택 완료율',
+      higherIsBetter: true,
+    },
+    {
+      label: 'Friction Score',
+      value: oqs.frictionScore,
+      unit: '%',
+      explanation: '파싱 오류 + 지역 누락 평균',
+      higherIsBetter: false,
+    },
+  ];
+
+  return (
+    <div className="rounded-xl border border-gray-100 bg-white shadow-sm p-6 mb-1">
+      <div className="flex flex-col md:flex-row md:items-start gap-6">
+        {/* Main OQS number */}
+        <div className="flex flex-col gap-1.5 shrink-0">
+          <span className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
+            Odiga Quality Score
+          </span>
+          <div className="flex items-end gap-3">
+            <span className="text-7xl font-bold tabular-nums leading-none text-orange-500">
+              {oqs.oqs}
+            </span>
+            <div className="flex flex-col gap-1 pb-1">
+              <span
+                className={cn(
+                  'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold',
+                  deltaPositive
+                    ? 'bg-emerald-50 text-emerald-700'
+                    : 'bg-red-50 text-red-600',
+                )}
+              >
+                {deltaPositive ? '+' : ''}{oqs.delta.toFixed(1)}
+              </span>
+              <span className="text-[10px] text-muted-foreground whitespace-nowrap">vs 이전 기간</span>
+            </div>
+          </div>
+          <span className="text-xs text-muted-foreground">
+            {totalSearches.toLocaleString()}건 분석
+          </span>
+        </div>
+
+        {/* Divider */}
+        <div className="hidden md:block w-px self-stretch bg-gray-100 mx-2" />
+
+        {/* Sub-metrics */}
+        <div className="flex flex-wrap gap-3 flex-1">
+          {subMetrics.map((m) => (
+            <SubMetricCard key={m.label} metric={m} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/admin/src/components/odiga-quality/IntentMatchTable.tsx
+++ b/admin/src/components/odiga-quality/IntentMatchTable.tsx
@@ -1,0 +1,109 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import type { IntentRow } from '@/types/odiga-quality';
+
+const STATUS_CONFIG = {
+  healthy: {
+    label: '정상',
+    dotClass: 'bg-emerald-500',
+    textClass: 'text-emerald-700',
+  },
+  watch: {
+    label: '주의',
+    dotClass: 'bg-orange-400',
+    textClass: 'text-orange-600',
+  },
+  needs_improvement: {
+    label: '개선 필요',
+    dotClass: 'bg-red-500',
+    textClass: 'text-red-600',
+  },
+};
+
+interface IntentMatchTableProps {
+  rows: IntentRow[];
+}
+
+export function IntentMatchTable({ rows }: IntentMatchTableProps) {
+  if (rows.length === 0) {
+    return (
+      <Card className="shadow-sm rounded-xl border-gray-100 bg-white">
+        <div className="px-5 pt-5 pb-3">
+          <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Intent Match Quality</p>
+          <p className="text-xs text-muted-foreground/70 mt-0.5">활동 유형별 추천 품질 지표</p>
+        </div>
+        <CardContent>
+          <p className="text-sm text-muted-foreground py-4 text-center">데이터 없음</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="shadow-sm rounded-xl border-gray-100 bg-white">
+      <div className="px-5 pt-5 pb-3">
+        <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Intent Match Quality</p>
+        <p className="text-xs text-muted-foreground/70 mt-0.5">
+          활동 유형별 추천 품질 — FMQ ≥ 70% + 선택률 ≥ 30% = 정상
+        </p>
+      </div>
+      <CardContent className="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-gray-100 bg-gray-50/60">
+              <TableHead className="pl-5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Intent</TableHead>
+              <TableHead className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">요청수</TableHead>
+              <TableHead className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">FMQ</TableHead>
+              <TableHead className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">선택률</TableHead>
+              <TableHead className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">재추천률</TableHead>
+              <TableHead className="text-right pr-5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">상태</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => {
+              const status = STATUS_CONFIG[row.status];
+              return (
+                <TableRow key={row.intent} className="border-gray-100 text-sm hover:bg-gray-50/50">
+                  <TableCell className="pl-5 font-medium">{row.intent}</TableCell>
+                  <TableCell className="text-right tabular-nums text-muted-foreground">
+                    {row.requestCount.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    <span
+                      className={cn(
+                        'font-semibold',
+                        row.fmq >= 70
+                          ? 'text-emerald-700'
+                          : row.fmq >= 50
+                            ? 'text-orange-500'
+                            : 'text-red-600',
+                      )}
+                    >
+                      {row.fmq}%
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">{row.saveRate}%</TableCell>
+                  <TableCell className="text-right tabular-nums">{row.rerollRate}%</TableCell>
+                  <TableCell className="text-right pr-5">
+                    <span className={cn('inline-flex items-center gap-1.5 text-xs font-medium', status.textClass)}>
+                      <span className={cn('h-1.5 w-1.5 rounded-full', status.dotClass)} />
+                      {status.label}
+                    </span>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin/src/components/odiga-quality/MetricCard.tsx
+++ b/admin/src/components/odiga-quality/MetricCard.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
+
+interface MetricCardProps {
+  title: string;
+  explanation?: string;
+  children: React.ReactNode;
+  className?: string;
+  detailsHref?: string;
+}
+
+export function MetricCard({ title, explanation, children, className, detailsHref }: MetricCardProps) {
+  return (
+    <Card className={cn('flex flex-col shadow-sm rounded-xl border-gray-100 bg-white', className)}>
+      <div className="flex items-start justify-between px-5 pt-5 pb-3">
+        <div>
+          <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
+            {title}
+          </p>
+          {explanation && (
+            <p className="text-xs text-muted-foreground/70 mt-0.5">{explanation}</p>
+          )}
+        </div>
+        {detailsHref && (
+          <Link
+            href={detailsHref}
+            className="text-xs text-muted-foreground hover:text-orange-500 transition-colors shrink-0 ml-3 mt-0.5"
+          >
+            Details →
+          </Link>
+        )}
+      </div>
+      <CardContent className="flex-1 px-5 pb-5">{children}</CardContent>
+    </Card>
+  );
+}

--- a/admin/src/components/odiga-quality/TrustEngagementCard.tsx
+++ b/admin/src/components/odiga-quality/TrustEngagementCard.tsx
@@ -1,0 +1,50 @@
+import { MetricCard } from './MetricCard';
+import type { TrustMetrics } from '@/types/odiga-quality';
+
+interface TrustEngagementCardProps {
+  data: TrustMetrics;
+}
+
+function ProgressRow({
+  label,
+  value,
+  emphasis,
+}: {
+  label: string;
+  value: number;
+  emphasis?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between">
+        <span className={emphasis ? 'text-sm font-semibold' : 'text-xs text-muted-foreground'}>
+          {label}
+        </span>
+        <span className={emphasis ? 'text-lg font-bold tabular-nums' : 'text-sm font-medium tabular-nums'}>
+          {value.toFixed(1)}%
+        </span>
+      </div>
+      <div className="h-1.5 w-full rounded-full bg-gray-100 overflow-hidden">
+        <div
+          className="h-full rounded-full transition-all bg-orange-400"
+          style={{ width: `${Math.min(100, value)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function TrustEngagementCard({ data }: TrustEngagementCardProps) {
+  return (
+    <MetricCard
+      title="Trust & Engagement"
+      explanation="사용자가 추천을 얼마나 신뢰하고 행동했는지"
+    >
+      <div className="flex flex-col gap-5 pt-1">
+        <ProgressRow label="선택/저장률 (Save Rate)" value={data.saveRate} emphasis />
+        <ProgressRow label="피드백 참여율" value={data.engagementRate} />
+        <ProgressRow label="코스 완료율" value={data.courseCompletionRate} />
+      </div>
+    </MetricCard>
+  );
+}

--- a/admin/src/lib/queries/odiga-quality.ts
+++ b/admin/src/lib/queries/odiga-quality.ts
@@ -1,0 +1,442 @@
+import { createServerSupabase } from '@/lib/supabase/server';
+import type {
+  QualityFilters,
+  QualityData,
+  OQSMetrics,
+  FirstMatchMetrics,
+  TrustMetrics,
+  IntentRow,
+  CourseMetrics,
+  FrictionMetrics,
+  DBPressureRow,
+  AlertItem,
+} from '@/types/odiga-quality';
+
+// ---------------------------------------------------------------------------
+// Date range helpers
+// ---------------------------------------------------------------------------
+
+export function buildDateRange(period: QualityFilters['period']): { from: string; to: string } {
+  const now = new Date();
+  const to = now.toISOString();
+  const days = period === '1d' ? 1 : period === '7d' ? 7 : 30;
+  const from = new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+  return { from, to };
+}
+
+function previousRange(period: QualityFilters['period']): { from: string; to: string } {
+  const days = period === '1d' ? 1 : period === '7d' ? 7 : 30;
+  const now = new Date();
+  const to = new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+  const from = new Date(now.getTime() - days * 2 * 24 * 60 * 60 * 1000).toISOString();
+  return { from, to };
+}
+
+function dateKey(iso: string): string {
+  return iso.split('T')[0];
+}
+
+// ---------------------------------------------------------------------------
+// Computation helpers
+// ---------------------------------------------------------------------------
+
+type LogRow = {
+  created_at: string;
+  region: string | null;
+  response_type: string | null;
+  activity_type: string | null;
+  selected_place_id: string | null;
+  selected_course: unknown;
+  regenerate_count: number | null;
+  parse_error_fields: string[] | null;
+  user_feedbacks: string[] | null;
+};
+
+function hasSelection(row: LogRow): boolean {
+  return row.selected_place_id !== null || row.selected_course !== null;
+}
+
+function hasFeedback(row: LogRow): boolean {
+  return Array.isArray(row.user_feedbacks) && row.user_feedbacks.length > 0;
+}
+
+function computeOQS(
+  fmq: number,
+  selectionRate: number,
+  frictionScore: number,
+  courseCompletion: number,
+): number {
+  const raw = fmq * 0.35 + selectionRate * 0.30 + (100 - frictionScore) * 0.20 + courseCompletion * 0.15;
+  return Math.round(Math.min(100, Math.max(0, raw)));
+}
+
+function intentStatus(fmq: number, saveRate: number): IntentRow['status'] {
+  if (fmq >= 70 && saveRate >= 30) return 'healthy';
+  if (fmq >= 50 || saveRate >= 20) return 'watch';
+  return 'needs_improvement';
+}
+
+function pressureStatus(score: number): DBPressureRow['status'] {
+  if (score >= 4) return 'critical';
+  if (score >= 2) return 'warn';
+  return 'ok';
+}
+
+function generateAlerts(data: {
+  fmq: number;
+  selectionRate: number;
+  prevSelectionRate: number;
+  parseErrorRate: number;
+  dbPressure: DBPressureRow[];
+}): AlertItem[] {
+  const alerts: AlertItem[] = [];
+
+  if (data.fmq < 60) {
+    alerts.push({
+      type: 'error',
+      message: `FMQ ${data.fmq.toFixed(1)}% — 첫 추천 만족도가 낮습니다`,
+      metric: 'FMQ',
+      value: data.fmq,
+      threshold: 60,
+    });
+  }
+
+  const selectionDrop = data.prevSelectionRate - data.selectionRate;
+  if (selectionDrop > 10) {
+    alerts.push({
+      type: 'warn',
+      message: `선택률 ${selectionDrop.toFixed(1)}% 하락 (이전 기간 대비)`,
+      metric: 'SelectionRate',
+      value: data.selectionRate,
+      threshold: data.prevSelectionRate - 10,
+    });
+  }
+
+  if (data.parseErrorRate > 20) {
+    alerts.push({
+      type: 'warn',
+      message: `파싱 오류율 ${data.parseErrorRate.toFixed(1)}% — 인텐트 파싱 품질 점검 필요`,
+      metric: 'ParseErrorRate',
+      value: data.parseErrorRate,
+      threshold: 20,
+    });
+  }
+
+  for (const row of data.dbPressure) {
+    if (row.status === 'critical') {
+      alerts.push({
+        type: 'warn',
+        message: `${row.region} 지역 DB 압력 ${row.pressureScore.toFixed(1)}x — 장소 데이터 부족`,
+        metric: 'DBPressure',
+        value: row.pressureScore,
+        threshold: 4,
+      });
+    }
+  }
+
+  return alerts;
+}
+
+// ---------------------------------------------------------------------------
+// Filter helpers
+// ---------------------------------------------------------------------------
+
+export function parseFilters(params: Record<string, string | undefined>): QualityFilters {
+  const period = (['1d', '7d', '30d'] as const).includes(params.period as QualityFilters['period'])
+    ? (params.period as QualityFilters['period'])
+    : '7d';
+
+  const response_type = (['all', 'single', 'course'] as const).includes(
+    params.response_type as QualityFilters['response_type'],
+  )
+    ? (params.response_type as QualityFilters['response_type'])
+    : 'all';
+
+  return {
+    period,
+    region: params.region ?? null,
+    response_type,
+    activity_type: params.activity_type ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main query function
+// ---------------------------------------------------------------------------
+
+export async function getQualityData(filters: QualityFilters): Promise<QualityData> {
+  const supabase = await createServerSupabase();
+  const dateRange = buildDateRange(filters.period);
+  const prevRange = previousRange(filters.period);
+
+  // Build base query for current period
+  function buildLogQuery(from: string, to: string) {
+    let q = supabase
+      .from('odiga_search_logs')
+      .select(
+        'created_at, region, response_type, activity_type, selected_place_id, selected_course, regenerate_count, parse_error_fields, user_feedbacks',
+      )
+      .gte('created_at', from)
+      .lte('created_at', to);
+
+    if (filters.region) q = q.eq('region', filters.region);
+    if (filters.response_type !== 'all') q = q.eq('response_type', filters.response_type);
+    if (filters.activity_type) q = q.eq('activity_type', filters.activity_type);
+
+    return q;
+  }
+
+  const [
+    { data: currentLogs },
+    { data: prevLogs },
+    { data: savedCoursesRaw },
+    { data: locationRegions },
+    { data: attractionRegions },
+  ] = await Promise.all([
+    buildLogQuery(dateRange.from, dateRange.to),
+    buildLogQuery(prevRange.from, prevRange.to),
+    supabase
+      .from('odiga_saved_courses')
+      .select('created_at, region')
+      .gte('created_at', dateRange.from)
+      .lte('created_at', dateRange.to),
+    supabase.from('locations').select('region'),
+    supabase.from('attractions').select('region'),
+  ]);
+
+  const logs: LogRow[] = (currentLogs ?? []) as LogRow[];
+  const prevLogRows: LogRow[] = (prevLogs ?? []) as LogRow[];
+  const total = logs.length;
+  const prevTotal = prevLogRows.length;
+
+  // ---------------------------------------------------------------------------
+  // First Match Quality
+  // ---------------------------------------------------------------------------
+  const zeroReroll = logs.filter((r) => (r.regenerate_count ?? 0) === 0).length;
+  const oneReroll = logs.filter((r) => (r.regenerate_count ?? 0) === 1).length;
+  const twoPlus = logs.filter((r) => (r.regenerate_count ?? 0) >= 2).length;
+  const totalRerolls = logs.reduce((s, r) => s + (r.regenerate_count ?? 0), 0);
+
+  const zeroRerollRate = total > 0 ? (zeroReroll / total) * 100 : 0;
+  const firstSelectRate = total > 0 ? (logs.filter(hasSelection).length / total) * 100 : 0;
+  const avgRerollCount = total > 0 ? totalRerolls / total : 0;
+
+  const firstMatch: FirstMatchMetrics = {
+    zeroRerollRate,
+    firstSelectRate,
+    avgRerollCount,
+    distribution: { zero: zeroReroll, one: oneReroll, twoPlus },
+  };
+
+  // ---------------------------------------------------------------------------
+  // Trust & Engagement
+  // ---------------------------------------------------------------------------
+  const selectedCount = logs.filter(hasSelection).length;
+  const engagedCount = logs.filter(hasFeedback).length;
+  const courseTotal = logs.filter((r) => r.response_type === 'course').length;
+  const courseSelected = logs.filter(
+    (r) => r.response_type === 'course' && r.selected_course !== null,
+  ).length;
+
+  const saveRate = total > 0 ? (selectedCount / total) * 100 : 0;
+  const engagementRate = total > 0 ? (engagedCount / total) * 100 : 0;
+  const courseCompletionRate = courseTotal > 0 ? (courseSelected / courseTotal) * 100 : 0;
+
+  const trust: TrustMetrics = { saveRate, engagementRate, courseCompletionRate };
+
+  // ---------------------------------------------------------------------------
+  // Friction
+  // ---------------------------------------------------------------------------
+  const regionMissingCount = logs.filter((r) => !r.region).length;
+  const noSelectionCount = logs.filter((r) => !hasSelection(r)).length;
+  const parseErrCount = logs.filter(
+    (r) => Array.isArray(r.parse_error_fields) && r.parse_error_fields.length > 0,
+  ).length;
+
+  const regionMissingRate = total > 0 ? (regionMissingCount / total) * 100 : 0;
+  const noSelectionRate = total > 0 ? (noSelectionCount / total) * 100 : 0;
+  const parseErrorRate = total > 0 ? (parseErrCount / total) * 100 : 0;
+
+  // Parse error field breakdown
+  const fieldMap = new Map<string, number>();
+  for (const row of logs) {
+    for (const field of row.parse_error_fields ?? []) {
+      fieldMap.set(field, (fieldMap.get(field) ?? 0) + 1);
+    }
+  }
+  const parseErrorBreakdown = Array.from(fieldMap.entries())
+    .map(([field, count]) => ({ field, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+
+  const frictionScore = (parseErrorRate + regionMissingRate) / 2;
+  const friction: FrictionMetrics = {
+    regionMissingRate,
+    noSelectionRate,
+    parseErrorRate,
+    parseErrorBreakdown,
+  };
+
+  // ---------------------------------------------------------------------------
+  // OQS
+  // ---------------------------------------------------------------------------
+  const fmq = zeroRerollRate;
+  const oqsScore = computeOQS(fmq, saveRate, frictionScore, courseCompletionRate);
+
+  // Previous period OQS for delta
+  const prevSelected = prevLogRows.filter(hasSelection).length;
+  const prevSaveRate = prevTotal > 0 ? (prevSelected / prevTotal) * 100 : 0;
+  const prevZeroReroll = prevLogRows.filter((r) => (r.regenerate_count ?? 0) === 0).length;
+  const prevFmq = prevTotal > 0 ? (prevZeroReroll / prevTotal) * 100 : 0;
+  const prevRegionMissing = prevLogRows.filter((r) => !r.region).length;
+  const prevParseErr = prevLogRows.filter(
+    (r) => Array.isArray(r.parse_error_fields) && r.parse_error_fields.length > 0,
+  ).length;
+  const prevFriction =
+    prevTotal > 0
+      ? ((prevRegionMissing / prevTotal) * 100 + (prevParseErr / prevTotal) * 100) / 2
+      : 0;
+  const prevCourseTotal = prevLogRows.filter((r) => r.response_type === 'course').length;
+  const prevCourseSelected = prevLogRows.filter(
+    (r) => r.response_type === 'course' && r.selected_course !== null,
+  ).length;
+  const prevCourseCompletion = prevCourseTotal > 0 ? (prevCourseSelected / prevCourseTotal) * 100 : 0;
+  const prevOqs = computeOQS(prevFmq, prevSaveRate, prevFriction, prevCourseCompletion);
+
+  const oqs: OQSMetrics = {
+    oqs: oqsScore,
+    delta: oqsScore - prevOqs,
+    fmq,
+    trustIndex: saveRate,
+    courseCompletion: courseCompletionRate,
+    frictionScore,
+  };
+
+  // ---------------------------------------------------------------------------
+  // Intent breakdown (by activity_type)
+  // ---------------------------------------------------------------------------
+  const intentMap = new Map<
+    string,
+    { total: number; zeroReroll: number; selected: number; rerolls: number }
+  >();
+
+  for (const row of logs) {
+    const intent = row.activity_type ?? '기타';
+    if (!intentMap.has(intent)) {
+      intentMap.set(intent, { total: 0, zeroReroll: 0, selected: 0, rerolls: 0 });
+    }
+    const bucket = intentMap.get(intent)!;
+    bucket.total += 1;
+    if ((row.regenerate_count ?? 0) === 0) bucket.zeroReroll += 1;
+    if (hasSelection(row)) bucket.selected += 1;
+    bucket.rerolls += row.regenerate_count ?? 0;
+  }
+
+  const intents: IntentRow[] = Array.from(intentMap.entries())
+    .map(([intent, bucket]) => {
+      const intentFmq = bucket.total > 0 ? (bucket.zeroReroll / bucket.total) * 100 : 0;
+      const intentSaveRate = bucket.total > 0 ? (bucket.selected / bucket.total) * 100 : 0;
+      const intentRerollRate = bucket.total > 0 ? (bucket.rerolls / bucket.total) * 100 : 0;
+      return {
+        intent,
+        requestCount: bucket.total,
+        fmq: Math.round(intentFmq),
+        saveRate: Math.round(intentSaveRate),
+        rerollRate: Math.round(intentRerollRate),
+        status: intentStatus(intentFmq, intentSaveRate),
+      };
+    })
+    .sort((a, b) => b.requestCount - a.requestCount);
+
+  // ---------------------------------------------------------------------------
+  // Course Quality
+  // ---------------------------------------------------------------------------
+  const courseLogs = logs.filter((r) => r.response_type === 'course');
+  const courseSelectRate = courseTotal > 0 ? (courseSelected / courseTotal) * 100 : 0;
+  const savedCoursesCount = (savedCoursesRaw ?? []).length;
+  const courseSaveRate = courseTotal > 0 ? (savedCoursesCount / courseTotal) * 100 : 0;
+  const courseRerolls = courseLogs.reduce((s, r) => s + (r.regenerate_count ?? 0), 0);
+  const courseAvgReroll = courseTotal > 0 ? courseRerolls / courseTotal : 0;
+
+  // Daily selection trend
+  const trendMap = new Map<string, { total: number; selected: number }>();
+  for (const row of courseLogs) {
+    const d = dateKey(row.created_at);
+    if (!trendMap.has(d)) trendMap.set(d, { total: 0, selected: 0 });
+    const bucket = trendMap.get(d)!;
+    bucket.total += 1;
+    if (row.selected_course !== null) bucket.selected += 1;
+  }
+  const selectionTrend = Array.from(trendMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, bucket]) => ({
+      date,
+      rate: bucket.total > 0 ? Math.round((bucket.selected / bucket.total) * 100) : 0,
+    }));
+
+  const course: CourseMetrics = {
+    requestCount: courseTotal,
+    selectionRate: courseSelectRate,
+    saveRate: courseSaveRate,
+    avgReroll: courseAvgReroll,
+    selectionTrend,
+  };
+
+  // ---------------------------------------------------------------------------
+  // DB Pressure
+  // ---------------------------------------------------------------------------
+  const regionRequestMap = new Map<string, number>();
+  for (const row of logs) {
+    const r = row.region || '미지정';
+    regionRequestMap.set(r, (regionRequestMap.get(r) ?? 0) + 1);
+  }
+
+  const placeRegionMap = new Map<string, number>();
+  for (const loc of locationRegions ?? []) {
+    const r = (loc as { region?: string }).region || '미지정';
+    placeRegionMap.set(r, (placeRegionMap.get(r) ?? 0) + 1);
+  }
+  for (const attr of attractionRegions ?? []) {
+    const r = (attr as { region?: string }).region || '미지정';
+    placeRegionMap.set(r, (placeRegionMap.get(r) ?? 0) + 1);
+  }
+
+  const dbPressure: DBPressureRow[] = Array.from(regionRequestMap.entries())
+    .map(([region, requestCount]) => {
+      const placeCount = placeRegionMap.get(region) ?? 0;
+      const pressureScore = placeCount > 0 ? requestCount / placeCount : requestCount;
+      return {
+        region,
+        requestCount,
+        placeCount,
+        pressureScore: Math.round(pressureScore * 10) / 10,
+        status: pressureStatus(pressureScore),
+      };
+    })
+    .sort((a, b) => b.pressureScore - a.pressureScore)
+    .slice(0, 15);
+
+  // ---------------------------------------------------------------------------
+  // Alerts
+  // ---------------------------------------------------------------------------
+  const alerts: AlertItem[] = generateAlerts({
+    fmq,
+    selectionRate: saveRate,
+    prevSelectionRate: prevSaveRate,
+    parseErrorRate,
+    dbPressure,
+  });
+
+  return {
+    oqs,
+    firstMatch,
+    trust,
+    intents,
+    course,
+    friction,
+    dbPressure,
+    alerts,
+    totalSearches: total,
+    dateRange,
+  };
+}

--- a/admin/src/types/odiga-quality.ts
+++ b/admin/src/types/odiga-quality.ts
@@ -1,0 +1,87 @@
+export interface QualityFilters {
+  period: '1d' | '7d' | '30d';
+  region: string | null;
+  response_type: 'all' | 'single' | 'course';
+  activity_type: string | null;
+}
+
+export interface OQSMetrics {
+  oqs: number;
+  delta: number;
+  fmq: number;
+  trustIndex: number;
+  courseCompletion: number;
+  frictionScore: number;
+}
+
+export interface RerollDistribution {
+  zero: number;
+  one: number;
+  twoPlus: number;
+}
+
+export interface FirstMatchMetrics {
+  zeroRerollRate: number;
+  firstSelectRate: number;
+  avgRerollCount: number;
+  distribution: RerollDistribution;
+}
+
+export interface TrustMetrics {
+  saveRate: number;
+  engagementRate: number;
+  courseCompletionRate: number;
+}
+
+export interface IntentRow {
+  intent: string;
+  requestCount: number;
+  fmq: number;
+  saveRate: number;
+  rerollRate: number;
+  status: 'healthy' | 'watch' | 'needs_improvement';
+}
+
+export interface CourseMetrics {
+  requestCount: number;
+  selectionRate: number;
+  saveRate: number;
+  avgReroll: number;
+  selectionTrend: { date: string; rate: number }[];
+}
+
+export interface FrictionMetrics {
+  regionMissingRate: number;
+  noSelectionRate: number;
+  parseErrorRate: number;
+  parseErrorBreakdown: { field: string; count: number }[];
+}
+
+export interface DBPressureRow {
+  region: string;
+  requestCount: number;
+  placeCount: number;
+  pressureScore: number;
+  status: 'ok' | 'warn' | 'critical';
+}
+
+export interface AlertItem {
+  type: 'error' | 'warn';
+  message: string;
+  metric: string;
+  value: number;
+  threshold: number;
+}
+
+export interface QualityData {
+  oqs: OQSMetrics;
+  firstMatch: FirstMatchMetrics;
+  trust: TrustMetrics;
+  intents: IntentRow[];
+  course: CourseMetrics;
+  friction: FrictionMetrics;
+  dbPressure: DBPressureRow[];
+  alerts: AlertItem[];
+  totalSearches: number;
+  dateRange: { from: string; to: string };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.1",
+        "recharts": "^3.7.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "zod": "^4.3.6"
@@ -4293,6 +4294,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@renovatebot/pep440": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@renovatebot/pep440/-/pep440-4.2.1.tgz",
@@ -5229,6 +5266,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5308,6 +5408,12 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -7627,6 +7733,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -7730,6 +7957,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.1",
@@ -8332,6 +8565,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.0",
@@ -10200,6 +10443,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -10257,6 +10510,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -13946,8 +14208,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -14091,6 +14375,57 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -14169,6 +14504,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -15533,7 +15874,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -16278,6 +16618,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {


### PR DESCRIPTION
## Summary

Closes #30

- `/odiga-quality` 경로에 Odiga AI 추천 품질 실시간 모니터링 콘솔 구현
- 17개 파일, 약 1,920줄 추가

## 변경 내용

### 신규 파일
| 분류 | 파일 |
|---|---|
| 타입 | `src/types/odiga-quality.ts` |
| 쿼리 | `src/lib/queries/odiga-quality.ts` |
| 페이지 | `src/app/odiga-quality/page.tsx`, `loading.tsx` |
| 컴포넌트 | `FilterBar`, `HeroSection`, `FirstMatchCard`, `TrustEngagementCard`, `IntentMatchTable`, `CourseQualityCard`, `FrictionScoreCard`, `DBPressureTable`, `AlertPanel`, `MetricCard` |

### 수정 파일
- `Sidebar.tsx` — Quality Console 메뉴 항목 추가
- `package.json` — recharts 패키지 추가

## 주요 기능

- **OQS 히어로** — `FMQ×0.35 + 선택률×0.30 + (100−마찰)×0.20 + 코스완료×0.15`
- **스티키 필터바** — 기간/응답유형/활동유형 URL searchParams 필터
- **5개 메트릭 카드** — BarChart, AreaChart, PieChart (Recharts)
- **2개 테이블** — Intent Match / DB Pressure (압력 지수 바 시각화)
- **Alert Panel** — 우하단 고정, FMQ < 60 / 파싱오류 > 20% 등 자동 감지

## UI 디자인

Catalyst SaaS 스타일:
- 오렌지 브랜드 컬러 `#FF8A3D` (차트, pill 활성 상태, 강조 숫자)
- 흰색 카드 + `shadow-sm rounded-xl`
- 레이블-위-숫자 레이아웃, 델타 pill 배지

## 사전 조건 (배포 전 필수)

Supabase에서 `odiga_search_logs` 테이블에 authenticated/anon READ RLS 정책 추가 필요

## Test plan

- [ ] `/odiga-quality` 접속 시 로딩 스켈레톤 → 데이터 렌더링 확인
- [ ] 기간 필터 (오늘/7일/30일) pill 클릭 시 URL 변경 + 데이터 재조회
- [ ] 응답유형/활동유형 Select 필터 동작 확인
- [ ] 데이터 없을 때 "데이터 없음" 표시 확인
- [ ] Alert Panel 알림 항목 펼치기/접기

🤖 Generated with [Claude Code](https://claude.com/claude-code)