### PR TITLE
feat(admin): Weekly Todo Tracker 페이지 추가

### DIFF
--- a/admin/src/app/todo/ContributionGraph.tsx
+++ b/admin/src/app/todo/ContributionGraph.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import type { TaskType } from '@/lib/queries/todo';
+
+interface ContributionCell {
+  weekStart: string;
+  completed: boolean;
+}
+
+interface ContributionRow {
+  taskType: TaskType;
+  label: string;
+  cells: ContributionCell[]; // 오래된 것이 [0], 최신이 [마지막]
+}
+
+interface ContributionGraphProps {
+  rows: ContributionRow[];
+}
+
+/** YYYY-MM-DD → "M월 D주차" 형태 툴팁 */
+function formatWeekLabel(weekStart: string): string {
+  const d = new Date(weekStart + 'T00:00:00');
+  const month = d.getMonth() + 1;
+  const day = d.getDate();
+  return `${month}/${day} 주`;
+}
+
+/** 월 레이블 위치 계산: 셀 인덱스 배열 → 월이 바뀌는 지점 반환 */
+function getMonthLabels(cells: ContributionCell[]): { index: number; label: string }[] {
+  const labels: { index: number; label: string }[] = [];
+  let lastMonth = -1;
+  cells.forEach((cell, i) => {
+    const month = new Date(cell.weekStart + 'T00:00:00').getMonth();
+    if (month !== lastMonth) {
+      const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+      labels.push({ index: i, label: monthNames[month] });
+      lastMonth = month;
+    }
+  });
+  return labels;
+}
+
+export function ContributionGraph({ rows }: ContributionGraphProps) {
+  if (rows.length === 0) return null;
+
+  const cellSize = 14;
+  const cellGap = 3;
+  const labelWidth = 140;
+  const cellCount = rows[0].cells.length;
+  const monthLabels = getMonthLabels(rows[0].cells);
+
+  return (
+    <div className="rounded-xl border bg-white p-5 shadow-sm dark:bg-slate-900">
+      <h2 className="mb-4 text-sm font-semibold text-slate-700 dark:text-slate-200">
+        26주 완료 기록
+      </h2>
+
+      {/* 월 레이블 */}
+      <div className="mb-1 flex" style={{ paddingLeft: labelWidth }}>
+        <div className="relative flex-1" style={{ height: 16 }}>
+          {monthLabels.map(({ index, label }) => (
+            <span
+              key={index}
+              className="absolute text-xs text-slate-400"
+              style={{ left: index * (cellSize + cellGap) }}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* 태스크별 행 */}
+      <div className="flex flex-col gap-2">
+        {rows.map((row) => (
+          <div key={row.taskType} className="flex items-center">
+            {/* 태스크명 */}
+            <span
+              className="shrink-0 text-xs text-slate-500 dark:text-slate-400"
+              style={{ width: labelWidth }}
+            >
+              {row.label}
+            </span>
+
+            {/* 셀 그리드 */}
+            <div className="flex gap-[3px]">
+              {row.cells.map((cell) => (
+                <div
+                  key={cell.weekStart}
+                  title={`${formatWeekLabel(cell.weekStart)} · ${cell.completed ? '완료' : '미완료'}`}
+                  className={`h-[14px] w-[14px] rounded-sm transition-colors ${
+                    cell.completed
+                      ? 'bg-sky-500'
+                      : 'bg-slate-100 dark:bg-slate-800'
+                  }`}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 범례 */}
+      <div className="mt-4 flex items-center gap-2 text-xs text-slate-400">
+        <span>미완료</span>
+        <div className="h-[14px] w-[14px] rounded-sm bg-slate-100 dark:bg-slate-800" />
+        <div className="h-[14px] w-[14px] rounded-sm bg-sky-500" />
+        <span>완료</span>
+      </div>
+    </div>
+  );
+}

--- a/admin/src/app/todo/TaskButton.tsx
+++ b/admin/src/app/todo/TaskButton.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useTransition } from 'react';
+import { toggleTask } from './actions';
+import type { TaskType } from '@/lib/queries/todo';
+
+interface TaskButtonProps {
+  taskType: TaskType;
+  label: string;
+  weekStart: string;
+  completed: boolean;
+}
+
+export function TaskButton({ taskType, label, weekStart, completed }: TaskButtonProps) {
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <button
+      type="button"
+      disabled={isPending}
+      onClick={() => startTransition(() => toggleTask(taskType, weekStart, completed))}
+      className={`flex w-full items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-colors disabled:opacity-60 ${
+        completed
+          ? 'bg-sky-500 text-white hover:bg-sky-600'
+          : 'bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700'
+      }`}
+    >
+      <span
+        className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 text-xs ${
+          completed
+            ? 'border-white bg-white text-sky-500'
+            : 'border-slate-400 dark:border-slate-500'
+        }`}
+      >
+        {completed && '✓'}
+      </span>
+      {label}
+    </button>
+  );
+}

--- a/admin/src/app/todo/actions.ts
+++ b/admin/src/app/todo/actions.ts
@@ -1,0 +1,13 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { upsertChecklist, type TaskType } from '@/lib/queries/todo';
+
+export async function toggleTask(
+  taskType: TaskType,
+  weekStart: string,
+  currentlyCompleted: boolean,
+): Promise<void> {
+  await upsertChecklist(taskType, weekStart, !currentlyCompleted);
+  revalidatePath('/todo');
+}

--- a/admin/src/app/todo/page.tsx
+++ b/admin/src/app/todo/page.tsx
@@ -1,0 +1,132 @@
+import { AdminLayout } from '@/components/layout/AdminLayout';
+import {
+  getChecklistRecords,
+  getPastWeeks,
+  getWeekStart,
+  TASK_LABELS,
+  TASKS,
+  type ChecklistRow,
+  type TaskType,
+} from '@/lib/queries/todo';
+import { TaskButton } from './TaskButton';
+import { ContributionGraph } from './ContributionGraph';
+
+const WEEK_COUNT = 26;
+
+interface TaskStats {
+  completedWeeks: number;
+  totalWeeks: number;
+  currentStreak: number;
+}
+
+function computeStats(
+  taskType: TaskType,
+  weeks: string[], // 최신순
+  recordMap: Map<string, Map<TaskType, boolean>>,
+): TaskStats {
+  const completedWeeks = weeks.filter((w) => recordMap.get(w)?.get(taskType) ?? false).length;
+
+  let currentStreak = 0;
+  for (const week of weeks) {
+    if (recordMap.get(week)?.get(taskType)) {
+      currentStreak++;
+    } else {
+      break;
+    }
+  }
+
+  return { completedWeeks, totalWeeks: weeks.length, currentStreak };
+}
+
+export default async function TodoPage() {
+  const weeks = getPastWeeks(WEEK_COUNT); // 최신순 (weeks[0] = 이번 주)
+  const currentWeek = weeks[0];
+  const records = await getChecklistRecords(weeks);
+
+  // week_start → taskType → completed 맵
+  const recordMap = new Map<string, Map<TaskType, boolean>>();
+  for (const row of records as ChecklistRow[]) {
+    if (!recordMap.has(row.week_start)) {
+      recordMap.set(row.week_start, new Map());
+    }
+    recordMap.get(row.week_start)!.set(row.task_type, row.completed);
+  }
+
+  // 태스크별 통계
+  const statsMap = new Map<TaskType, TaskStats>();
+  for (const task of TASKS) {
+    statsMap.set(task, computeStats(task, weeks, recordMap));
+  }
+
+  // 잔디 그래프용 데이터 (오래된 것이 앞)
+  const reversedWeeks = [...weeks].reverse();
+  const graphRows = TASKS.map((task) => ({
+    taskType: task,
+    label: TASK_LABELS[task],
+    cells: reversedWeeks.map((week) => ({
+      weekStart: week,
+      completed: recordMap.get(week)?.get(task) ?? false,
+    })),
+  }));
+
+  return (
+    <AdminLayout>
+      <div className="space-y-6 p-6">
+        <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Weekly Tasks</h1>
+
+        {/* 이번 주 체크리스트 */}
+        <div className="rounded-xl border bg-white p-5 shadow-sm dark:bg-slate-900">
+          <h2 className="mb-4 text-sm font-semibold text-slate-700 dark:text-slate-200">
+            이번 주 ({currentWeek})
+          </h2>
+          <div className="flex flex-col gap-2">
+            {TASKS.map((task) => (
+              <TaskButton
+                key={task}
+                taskType={task}
+                label={TASK_LABELS[task]}
+                weekStart={currentWeek}
+                completed={recordMap.get(currentWeek)?.get(task) ?? false}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* 통계 카드 */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {TASKS.map((task) => {
+            const stats = statsMap.get(task)!;
+            const rate = Math.round((stats.completedWeeks / stats.totalWeeks) * 100);
+            return (
+              <div
+                key={task}
+                className="rounded-xl border bg-white p-4 shadow-sm dark:bg-slate-900"
+              >
+                <p className="mb-1 text-xs font-medium text-slate-500 dark:text-slate-400">
+                  {TASK_LABELS[task]}
+                </p>
+                <div className="flex items-end justify-between">
+                  <div>
+                    <p className="text-2xl font-bold text-sky-500">{rate}%</p>
+                    <p className="text-xs text-slate-400">
+                      {stats.completedWeeks}/{stats.totalWeeks}주 완료
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-lg font-semibold text-slate-700 dark:text-slate-200">
+                      🔥 {stats.currentStreak}주
+                    </p>
+                    <p className="text-xs text-slate-400">연속 완료</p>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* 잔디 그래프 */}
+        <ContributionGraph rows={graphRows} />
+      </div>
+    </AdminLayout>
+  );
+}

--- a/admin/src/components/layout/Sidebar.tsx
+++ b/admin/src/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { MapPin, AlertTriangle, Sparkles, Route, Bot, BarChart2 } from 'lucide-react';
+import { MapPin, AlertTriangle, Sparkles, Route, Bot, BarChart2, CheckSquare } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const navItems = [
@@ -12,6 +12,7 @@ const navItems = [
   { href: '/courses', label: '코스 관리', icon: Route },
   { href: '/locations/incomplete', label: '데이터 품질', icon: AlertTriangle },
   { href: '/content-engine', label: '콘텐츠 엔진', icon: Bot },
+  { href: '/todo', label: 'Weekly Tasks', icon: CheckSquare },
 ];
 
 export function Sidebar() {

--- a/admin/src/lib/queries/todo.ts
+++ b/admin/src/lib/queries/todo.ts
@@ -1,0 +1,81 @@
+import { createServerSupabase } from '@/lib/supabase/server';
+
+export type TaskType = 'threads' | 'movie_review' | 'odiga_tistory';
+
+export const TASK_LABELS: Record<TaskType, string> = {
+  threads: 'Threads 업로드',
+  movie_review: '영화리뷰 업로드',
+  odiga_tistory: '오늘오디가 티스토리',
+};
+
+export const TASKS: TaskType[] = ['threads', 'movie_review', 'odiga_tistory'];
+
+export interface ChecklistRow {
+  id: string;
+  task_type: TaskType;
+  week_start: string; // YYYY-MM-DD
+  completed: boolean;
+  completed_at: string | null;
+}
+
+/** 주어진 날짜가 속한 주의 월요일을 YYYY-MM-DD로 반환 */
+export function getWeekStart(date: Date): string {
+  const d = new Date(date);
+  const day = d.getDay(); // 0=Sun, 1=Mon, ...
+  const diff = day === 0 ? -6 : 1 - day; // 월요일로 이동
+  d.setDate(d.getDate() + diff);
+  return d.toISOString().slice(0, 10);
+}
+
+/** 최근 N주의 week_start 배열을 최신순으로 반환 */
+export function getPastWeeks(count: number): string[] {
+  const weeks: string[] = [];
+  const today = new Date();
+  const currentMonday = getWeekStart(today);
+
+  for (let i = 0; i < count; i++) {
+    const d = new Date(currentMonday);
+    d.setDate(d.getDate() - i * 7);
+    weeks.push(d.toISOString().slice(0, 10));
+  }
+  return weeks;
+}
+
+/** 특정 week_start 목록에 대한 체크리스트 레코드 조회 */
+export async function getChecklistRecords(weekStarts: string[]): Promise<ChecklistRow[]> {
+  const supabase = await createServerSupabase();
+  const { data, error } = await supabase
+    .from('weekly_checklist')
+    .select('id, task_type, week_start, completed, completed_at')
+    .in('week_start', weekStarts)
+    .order('week_start', { ascending: false });
+
+  if (error) {
+    console.error('[Todo] Failed to fetch checklist records:', error.message);
+    return [];
+  }
+  return (data ?? []) as ChecklistRow[];
+}
+
+/** 완료 상태 upsert (task_type + week_start 기준) */
+export async function upsertChecklist(
+  taskType: TaskType,
+  weekStart: string,
+  completed: boolean,
+): Promise<void> {
+  const supabase = await createServerSupabase();
+  const { error } = await supabase.from('weekly_checklist').upsert(
+    {
+      task_type: taskType,
+      week_start: weekStart,
+      completed,
+      completed_at: completed ? new Date().toISOString() : null,
+    },
+    { onConflict: 'task_type,week_start' },
+  );
+
+  if (error) {
+    console.error('[Todo] Failed to upsert checklist:', error.message);
+    throw error;
+  }
+}


### PR DESCRIPTION
closes #38

## Summary

- 반복 업무(Threads/영화리뷰/티스토리) 주간 완료 여부를 토글 버튼으로 관리
- 태스크별 완료율 + 연속 기록 통계 카드
- 26주 GitHub 잔디 스타일 히트맵 (`sky-500` 브랜드 컬러)
- Sidebar에 `Weekly Tasks` 메뉴 추가

## Test plan

- [ ] Supabase에서 `weekly_checklist` 테이블 SQL 실행
- [ ] `/todo` 접속 → 이번 주 카드 3개 버튼 확인
- [ ] 버튼 클릭 → DB upsert 확인 (sky-500으로 변경)
- [ ] 재클릭 → 미완료 토글 확인
- [ ] 통계 카드에 완료율 · 연속 기록 표시 확인
- [ ] 잔디 그래프에 완료된 주 셀 색상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)