### PR TITLE
fix(admin): Weekly Todo → Daily Todo로 변경

### DIFF
--- a/admin/src/app/todo/ContributionGraph.tsx
+++ b/admin/src/app/todo/ContributionGraph.tsx
@@ -2,39 +2,40 @@
 
 import type { TaskType } from '@/lib/queries/todo';
 
-interface ContributionCell {
-  weekStart: string;
+export interface DayCell {
+  date: string;
   completed: boolean;
 }
 
-interface ContributionRow {
+export interface GraphRow {
   taskType: TaskType;
   label: string;
-  cells: ContributionCell[]; // 오래된 것이 [0], 최신이 [마지막]
+  /** grid[weekIdx][dayIdx], weekIdx 0=가장 오래된 주, dayIdx 0=Mon~6=Sun */
+  grid: (DayCell | null)[][];
 }
 
 interface ContributionGraphProps {
-  rows: ContributionRow[];
+  rows: GraphRow[];
 }
 
-/** YYYY-MM-DD → "M월 D주차" 형태 툴팁 */
-function formatWeekLabel(weekStart: string): string {
-  const d = new Date(weekStart + 'T00:00:00');
-  const month = d.getMonth() + 1;
-  const day = d.getDate();
-  return `${month}/${day} 주`;
-}
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const DAY_LABELS = ['M', '', 'W', '', 'F', '', ''];
 
-/** 월 레이블 위치 계산: 셀 인덱스 배열 → 월이 바뀌는 지점 반환 */
-function getMonthLabels(cells: ContributionCell[]): { index: number; label: string }[] {
-  const labels: { index: number; label: string }[] = [];
+const CELL = 11;
+const GAP = 2;
+const STEP = CELL + GAP;
+
+function getMonthLabels(firstGrid: (DayCell | null)[][]): { weekIdx: number; label: string }[] {
+  const labels: { weekIdx: number; label: string }[] = [];
   let lastMonth = -1;
-  cells.forEach((cell, i) => {
-    const month = new Date(cell.weekStart + 'T00:00:00').getMonth();
-    if (month !== lastMonth) {
-      const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-      labels.push({ index: i, label: monthNames[month] });
-      lastMonth = month;
+  firstGrid.forEach((week, w) => {
+    const first = week.find((c) => c !== null);
+    if (first) {
+      const month = new Date(first.date + 'T00:00:00').getMonth();
+      if (month !== lastMonth) {
+        labels.push({ weekIdx: w, label: MONTH_NAMES[month] });
+        lastMonth = month;
+      }
     }
   });
   return labels;
@@ -43,26 +44,24 @@ function getMonthLabels(cells: ContributionCell[]): { index: number; label: stri
 export function ContributionGraph({ rows }: ContributionGraphProps) {
   if (rows.length === 0) return null;
 
-  const cellSize = 14;
-  const cellGap = 3;
-  const labelWidth = 140;
-  const cellCount = rows[0].cells.length;
-  const monthLabels = getMonthLabels(rows[0].cells);
+  const weekCount = rows[0].grid.length;
+  const monthLabels = getMonthLabels(rows[0].grid);
+  const LABEL_W = 132;
 
   return (
-    <div className="rounded-xl border bg-white p-5 shadow-sm dark:bg-slate-900">
+    <div className="overflow-x-auto rounded-xl border bg-white p-5 shadow-sm dark:bg-slate-900">
       <h2 className="mb-4 text-sm font-semibold text-slate-700 dark:text-slate-200">
         26주 완료 기록
       </h2>
 
       {/* 월 레이블 */}
-      <div className="mb-1 flex" style={{ paddingLeft: labelWidth }}>
-        <div className="relative flex-1" style={{ height: 16 }}>
-          {monthLabels.map(({ index, label }) => (
+      <div className="mb-1 flex" style={{ paddingLeft: LABEL_W }}>
+        <div className="relative" style={{ width: weekCount * STEP, height: 14 }}>
+          {monthLabels.map(({ weekIdx, label }) => (
             <span
-              key={index}
-              className="absolute text-xs text-slate-400"
-              style={{ left: index * (cellSize + cellGap) }}
+              key={weekIdx}
+              className="absolute text-[10px] text-slate-400"
+              style={{ left: weekIdx * STEP }}
             >
               {label}
             </span>
@@ -71,30 +70,52 @@ export function ContributionGraph({ rows }: ContributionGraphProps) {
       </div>
 
       {/* 태스크별 행 */}
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-5">
         {rows.map((row) => (
-          <div key={row.taskType} className="flex items-center">
-            {/* 태스크명 */}
-            <span
-              className="shrink-0 text-xs text-slate-500 dark:text-slate-400"
-              style={{ width: labelWidth }}
-            >
+          <div key={row.taskType}>
+            <p className="mb-1 text-xs font-medium text-slate-500 dark:text-slate-400">
               {row.label}
-            </span>
+            </p>
+            <div className="flex gap-0">
+              {/* 요일 레이블 */}
+              <div
+                className="mr-[6px] flex flex-col justify-between"
+                style={{ height: 7 * STEP - GAP }}
+              >
+                {DAY_LABELS.map((d, i) => (
+                  <span
+                    key={i}
+                    className="text-[9px] leading-none text-slate-300 dark:text-slate-600"
+                    style={{ height: CELL, lineHeight: `${CELL}px` }}
+                  >
+                    {d}
+                  </span>
+                ))}
+              </div>
 
-            {/* 셀 그리드 */}
-            <div className="flex gap-[3px]">
-              {row.cells.map((cell) => (
-                <div
-                  key={cell.weekStart}
-                  title={`${formatWeekLabel(cell.weekStart)} · ${cell.completed ? '완료' : '미완료'}`}
-                  className={`h-[14px] w-[14px] rounded-sm transition-colors ${
-                    cell.completed
-                      ? 'bg-sky-500'
-                      : 'bg-slate-100 dark:bg-slate-800'
-                  }`}
-                />
-              ))}
+              {/* 셀 그리드 */}
+              <div className="flex gap-[2px]">
+                {row.grid.map((week, w) => (
+                  <div key={w} className="flex flex-col gap-[2px]">
+                    {week.map((cell, d) =>
+                      cell ? (
+                        <div
+                          key={d}
+                          title={`${cell.date} · ${cell.completed ? '완료' : '미완료'}`}
+                          className={`rounded-[2px] transition-colors ${
+                            cell.completed
+                              ? 'bg-sky-500'
+                              : 'bg-slate-100 dark:bg-slate-800'
+                          }`}
+                          style={{ width: CELL, height: CELL }}
+                        />
+                      ) : (
+                        <div key={d} style={{ width: CELL, height: CELL }} />
+                      ),
+                    )}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         ))}
@@ -103,8 +124,11 @@ export function ContributionGraph({ rows }: ContributionGraphProps) {
       {/* 범례 */}
       <div className="mt-4 flex items-center gap-2 text-xs text-slate-400">
         <span>미완료</span>
-        <div className="h-[14px] w-[14px] rounded-sm bg-slate-100 dark:bg-slate-800" />
-        <div className="h-[14px] w-[14px] rounded-sm bg-sky-500" />
+        <div
+          className="rounded-[2px] bg-slate-100 dark:bg-slate-800"
+          style={{ width: CELL, height: CELL }}
+        />
+        <div className="rounded-[2px] bg-sky-500" style={{ width: CELL, height: CELL }} />
         <span>완료</span>
       </div>
     </div>

--- a/admin/src/app/todo/TaskButton.tsx
+++ b/admin/src/app/todo/TaskButton.tsx
@@ -7,18 +7,18 @@ import type { TaskType } from '@/lib/queries/todo';
 interface TaskButtonProps {
   taskType: TaskType;
   label: string;
-  weekStart: string;
+  date: string;
   completed: boolean;
 }
 
-export function TaskButton({ taskType, label, weekStart, completed }: TaskButtonProps) {
+export function TaskButton({ taskType, label, date, completed }: TaskButtonProps) {
   const [isPending, startTransition] = useTransition();
 
   return (
     <button
       type="button"
       disabled={isPending}
-      onClick={() => startTransition(() => toggleTask(taskType, weekStart, completed))}
+      onClick={() => startTransition(() => toggleTask(taskType, date, completed))}
       className={`flex w-full items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-colors disabled:opacity-60 ${
         completed
           ? 'bg-sky-500 text-white hover:bg-sky-600'

--- a/admin/src/app/todo/actions.ts
+++ b/admin/src/app/todo/actions.ts
@@ -5,9 +5,9 @@ import { upsertChecklist, type TaskType } from '@/lib/queries/todo';
 
 export async function toggleTask(
   taskType: TaskType,
-  weekStart: string,
+  date: string,
   currentlyCompleted: boolean,
 ): Promise<void> {
-  await upsertChecklist(taskType, weekStart, !currentlyCompleted);
+  await upsertChecklist(taskType, date, !currentlyCompleted);
   revalidatePath('/todo');
 }

--- a/admin/src/app/todo/page.tsx
+++ b/admin/src/app/todo/page.tsx
@@ -1,83 +1,127 @@
 import { AdminLayout } from '@/components/layout/AdminLayout';
 import {
   getChecklistRecords,
-  getPastWeeks,
-  getWeekStart,
+  getPastDays,
+  getToday,
   TASK_LABELS,
   TASKS,
   type ChecklistRow,
   type TaskType,
 } from '@/lib/queries/todo';
 import { TaskButton } from './TaskButton';
-import { ContributionGraph } from './ContributionGraph';
+import { ContributionGraph, type DayCell, type GraphRow } from './ContributionGraph';
 
-const WEEK_COUNT = 26;
+const DAY_COUNT = 182; // 26주
+
+// ── 통계 계산 ───────────────────────────────────────────────
 
 interface TaskStats {
-  completedWeeks: number;
-  totalWeeks: number;
-  currentStreak: number;
+  completedDays: number;
+  totalDays: number;
+  currentStreak: number; // 오늘부터 거슬러 올라가는 연속 완료 일수
 }
 
 function computeStats(
   taskType: TaskType,
-  weeks: string[], // 최신순
-  recordMap: Map<string, Map<TaskType, boolean>>,
+  days: string[], // 최신순
+  doneSet: Set<string>,
 ): TaskStats {
-  const completedWeeks = weeks.filter((w) => recordMap.get(w)?.get(taskType) ?? false).length;
+  const completedDays = days.filter((d) => doneSet.has(d)).length;
 
   let currentStreak = 0;
-  for (const week of weeks) {
-    if (recordMap.get(week)?.get(taskType)) {
-      currentStreak++;
-    } else {
-      break;
-    }
+  for (const day of days) {
+    if (doneSet.has(day)) currentStreak++;
+    else break;
   }
 
-  return { completedWeeks, totalWeeks: weeks.length, currentStreak };
+  return { completedDays, totalDays: days.length, currentStreak };
 }
 
-export default async function TodoPage() {
-  const weeks = getPastWeeks(WEEK_COUNT); // 최신순 (weeks[0] = 이번 주)
-  const currentWeek = weeks[0];
-  const records = await getChecklistRecords(weeks);
+// ── 잔디 그리드 생성 ─────────────────────────────────────────
 
-  // week_start → taskType → completed 맵
+/** 날짜 문자열로부터 월요일 기준 요일 인덱스 반환 (0=Mon, 6=Sun) */
+function dayOfWeekMon(dateStr: string): number {
+  const d = new Date(dateStr + 'T00:00:00Z');
+  return (d.getUTCDay() + 6) % 7;
+}
+
+/** 날짜 문자열로부터 N일 전 날짜 반환 */
+function subDays(dateStr: string, n: number): string {
+  const d = new Date(dateStr + 'T00:00:00Z');
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+function buildGrid(
+  days: string[], // 최신순 182일
+  doneSet: Set<string>,
+): (DayCell | null)[][] {
+  const today = days[0];
+  const oldest = days[days.length - 1];
+
+  // 가장 오래된 날짜가 속한 주의 월요일
+  const dow = dayOfWeekMon(oldest);
+  const startMonday = subDays(oldest, dow);
+
+  const daySet = new Set(days);
+  const grid: (DayCell | null)[][] = [];
+
+  for (let w = 0; w < 26; w++) {
+    const week: (DayCell | null)[] = [];
+    for (let d = 0; d < 7; d++) {
+      const cur = new Date(startMonday + 'T00:00:00Z');
+      cur.setUTCDate(cur.getUTCDate() + w * 7 + d);
+      const dateStr = cur.toISOString().slice(0, 10);
+
+      if (dateStr > today || !daySet.has(dateStr)) {
+        week.push(null);
+      } else {
+        week.push({ date: dateStr, completed: doneSet.has(dateStr) });
+      }
+    }
+    grid.push(week);
+  }
+
+  return grid;
+}
+
+// ── 페이지 ──────────────────────────────────────────────────
+
+export default async function TodoPage() {
+  const today = getToday();
+  const days = getPastDays(DAY_COUNT); // 최신순
+  const records = await getChecklistRecords(days);
+
+  // date → taskType → completed 맵
   const recordMap = new Map<string, Map<TaskType, boolean>>();
   for (const row of records as ChecklistRow[]) {
-    if (!recordMap.has(row.week_start)) {
-      recordMap.set(row.week_start, new Map());
-    }
-    recordMap.get(row.week_start)!.set(row.task_type, row.completed);
+    if (!recordMap.has(row.date)) recordMap.set(row.date, new Map());
+    recordMap.get(row.date)!.set(row.task_type, row.completed);
   }
 
-  // 태스크별 통계
-  const statsMap = new Map<TaskType, TaskStats>();
-  for (const task of TASKS) {
-    statsMap.set(task, computeStats(task, weeks, recordMap));
-  }
+  // 태스크별 완료 날짜 집합 + 통계 + 그리드
+  const taskData = TASKS.map((task) => {
+    const doneSet = new Set(days.filter((d) => recordMap.get(d)?.get(task) === true));
+    const stats = computeStats(task, days, doneSet);
+    const grid = buildGrid(days, doneSet);
+    return { task, stats, grid };
+  });
 
-  // 잔디 그래프용 데이터 (오래된 것이 앞)
-  const reversedWeeks = [...weeks].reverse();
-  const graphRows = TASKS.map((task) => ({
+  const graphRows: GraphRow[] = taskData.map(({ task, grid }) => ({
     taskType: task,
     label: TASK_LABELS[task],
-    cells: reversedWeeks.map((week) => ({
-      weekStart: week,
-      completed: recordMap.get(week)?.get(task) ?? false,
-    })),
+    grid,
   }));
 
   return (
     <AdminLayout>
       <div className="space-y-6 p-6">
-        <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Weekly Tasks</h1>
+        <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Daily Tasks</h1>
 
-        {/* 이번 주 체크리스트 */}
+        {/* 오늘 체크리스트 */}
         <div className="rounded-xl border bg-white p-5 shadow-sm dark:bg-slate-900">
           <h2 className="mb-4 text-sm font-semibold text-slate-700 dark:text-slate-200">
-            이번 주 ({currentWeek})
+            오늘 ({today})
           </h2>
           <div className="flex flex-col gap-2">
             {TASKS.map((task) => (
@@ -85,8 +129,8 @@ export default async function TodoPage() {
                 key={task}
                 taskType={task}
                 label={TASK_LABELS[task]}
-                weekStart={currentWeek}
-                completed={recordMap.get(currentWeek)?.get(task) ?? false}
+                date={today}
+                completed={recordMap.get(today)?.get(task) ?? false}
               />
             ))}
           </div>
@@ -94,9 +138,8 @@ export default async function TodoPage() {
 
         {/* 통계 카드 */}
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          {TASKS.map((task) => {
-            const stats = statsMap.get(task)!;
-            const rate = Math.round((stats.completedWeeks / stats.totalWeeks) * 100);
+          {taskData.map(({ task, stats }) => {
+            const rate = Math.round((stats.completedDays / stats.totalDays) * 100);
             return (
               <div
                 key={task}
@@ -109,12 +152,12 @@ export default async function TodoPage() {
                   <div>
                     <p className="text-2xl font-bold text-sky-500">{rate}%</p>
                     <p className="text-xs text-slate-400">
-                      {stats.completedWeeks}/{stats.totalWeeks}주 완료
+                      {stats.completedDays}/{stats.totalDays}일 완료
                     </p>
                   </div>
                   <div className="text-right">
                     <p className="text-lg font-semibold text-slate-700 dark:text-slate-200">
-                      🔥 {stats.currentStreak}주
+                      🔥 {stats.currentStreak}일
                     </p>
                     <p className="text-xs text-slate-400">연속 완료</p>
                   </div>


### PR DESCRIPTION
closes #40

## Summary

- 주 단위 → 일 단위 체크리스트로 전환
- `weekly_checklist` → `daily_checklist` 테이블 (DB SQL 수동 실행 필요)
- 잔디 그래프: 7행(Mon–Sun) × 26열(주) GitHub 스타일 레이아웃

## Test plan

- [ ] Supabase에서 `daily_checklist` 테이블 SQL 실행
- [ ] `/todo` → 오늘 날짜 카드 3개 버튼 확인
- [ ] 버튼 클릭 → sky-500 토글 확인
- [ ] 통계 카드에 완료율(일 단위) · 연속 완료 일수 확인
- [ ] 잔디 그래프 7×26 셀 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)