### PR TITLE
design(admin): Daily Tasks UI/UX 리디자인

### DIFF
--- a/admin/src/app/todo/ContributionGraph.tsx
+++ b/admin/src/app/todo/ContributionGraph.tsx
@@ -1,135 +1,159 @@
 'use client';
 
-import type { TaskType } from '@/lib/queries/todo';
-
-export interface DayCell {
-  date: string;
-  completed: boolean;
-}
-
-export interface GraphRow {
-  taskType: TaskType;
-  label: string;
-  /** grid[weekIdx][dayIdx], weekIdx 0=가장 오래된 주, dayIdx 0=Mon~6=Sun */
-  grid: (DayCell | null)[][];
-}
-
-interface ContributionGraphProps {
-  rows: GraphRow[];
+export interface ContributionGraphProps {
+  /** date (YYYY-MM-DD) → 완료된 태스크 수 (0~3) */
+  data: Map<string, number>;
+  /** 최신순 날짜 배열 (182일) */
+  days: string[];
 }
 
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 const DAY_LABELS = ['M', '', 'W', '', 'F', '', ''];
 
-const CELL = 11;
-const GAP = 2;
+const CELL = 14;
+const GAP = 3;
 const STEP = CELL + GAP;
 
-function getMonthLabels(firstGrid: (DayCell | null)[][]): { weekIdx: number; label: string }[] {
-  const labels: { weekIdx: number; label: string }[] = [];
-  let lastMonth = -1;
-  firstGrid.forEach((week, w) => {
-    const first = week.find((c) => c !== null);
-    if (first) {
-      const month = new Date(first.date + 'T00:00:00').getMonth();
-      if (month !== lastMonth) {
-        labels.push({ weekIdx: w, label: MONTH_NAMES[month] });
-        lastMonth = month;
-      }
-    }
-  });
-  return labels;
+/** date → 요일 인덱스 (0=Mon, 6=Sun) */
+function dayOfWeekMon(dateStr: string): number {
+  const d = new Date(dateStr + 'T00:00:00Z');
+  return (d.getUTCDay() + 6) % 7;
 }
 
-export function ContributionGraph({ rows }: ContributionGraphProps) {
-  if (rows.length === 0) return null;
+/** N일 뺀 날짜 */
+function subDays(dateStr: string, n: number): string {
+  const d = new Date(dateStr + 'T00:00:00Z');
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
 
-  const weekCount = rows[0].grid.length;
-  const monthLabels = getMonthLabels(rows[0].grid);
-  const LABEL_W = 132;
+/** 완료 수 → Tailwind 색상 클래스 */
+function cellColor(count: number): string {
+  switch (count) {
+    case 1: return 'bg-sky-200 dark:bg-sky-900';
+    case 2: return 'bg-sky-400';
+    case 3: return 'bg-sky-500';
+    default: return 'bg-slate-100 dark:bg-slate-800';
+  }
+}
+
+export function ContributionGraph({ data, days }: ContributionGraphProps) {
+  if (days.length === 0) return null;
+
+  const today = days[0];
+  const oldest = days[days.length - 1];
+  const daySet = new Set(days);
+
+  // 가장 오래된 날짜가 속한 주의 월요일
+  const dow = dayOfWeekMon(oldest);
+  const startMonday = subDays(oldest, dow);
+
+  // 26열(주) × 7행(요일) 그리드
+  const WEEKS = 26;
+  const grid: { date: string; count: number; inRange: boolean }[][] = [];
+  for (let w = 0; w < WEEKS; w++) {
+    const week: { date: string; count: number; inRange: boolean }[] = [];
+    for (let d = 0; d < 7; d++) {
+      const cur = new Date(startMonday + 'T00:00:00Z');
+      cur.setUTCDate(cur.getUTCDate() + w * 7 + d);
+      const dateStr = cur.toISOString().slice(0, 10);
+      week.push({
+        date: dateStr,
+        count: data.get(dateStr) ?? 0,
+        inRange: dateStr <= today && daySet.has(dateStr),
+      });
+    }
+    grid.push(week);
+  }
+
+  // 월 레이블 (겹침 방지: 최소 4주 간격)
+  const monthLabels: { weekIdx: number; label: string }[] = [];
+  let lastLabelWeek = -5;
+  for (let w = 0; w < WEEKS; w++) {
+    const first = grid[w].find((c) => c.inRange);
+    if (first && w - lastLabelWeek >= 4) {
+      const month = new Date(first.date + 'T00:00:00Z').getUTCMonth();
+      const prevLabel = monthLabels[monthLabels.length - 1];
+      if (!prevLabel || MONTH_NAMES[month] !== prevLabel.label) {
+        monthLabels.push({ weekIdx: w, label: MONTH_NAMES[month] });
+        lastLabelWeek = w;
+      }
+    }
+  }
+
+  const gridWidth = WEEKS * STEP - GAP;
 
   return (
     <div className="overflow-x-auto rounded-xl border bg-white p-5 shadow-sm dark:bg-slate-900">
       <h2 className="mb-4 text-sm font-semibold text-slate-700 dark:text-slate-200">
-        26주 완료 기록
+        26주 기록
       </h2>
 
-      {/* 월 레이블 */}
-      <div className="mb-1 flex" style={{ paddingLeft: LABEL_W }}>
-        <div className="relative" style={{ width: weekCount * STEP, height: 14 }}>
-          {monthLabels.map(({ weekIdx, label }) => (
-            <span
-              key={weekIdx}
-              className="absolute text-[10px] text-slate-400"
-              style={{ left: weekIdx * STEP }}
+      <div className="flex gap-3">
+        {/* 요일 레이블 */}
+        <div className="flex shrink-0 flex-col" style={{ paddingTop: 18, gap: GAP }}>
+          {DAY_LABELS.map((label, i) => (
+            <div
+              key={i}
+              className="text-[10px] leading-none text-slate-400 dark:text-slate-500"
+              style={{ height: CELL, lineHeight: `${CELL}px` }}
             >
               {label}
-            </span>
+            </div>
           ))}
+        </div>
+
+        <div>
+          {/* 월 레이블 */}
+          <div className="relative mb-1" style={{ width: gridWidth, height: 16 }}>
+            {monthLabels.map(({ weekIdx, label }) => (
+              <span
+                key={weekIdx}
+                className="absolute text-[10px] text-slate-400 dark:text-slate-500"
+                style={{ left: weekIdx * STEP }}
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+
+          {/* 셀 그리드 */}
+          <div className="flex" style={{ gap: GAP }}>
+            {grid.map((week, w) => (
+              <div key={w} className="flex flex-col" style={{ gap: GAP }}>
+                {week.map((cell, d) => (
+                  <div
+                    key={d}
+                    title={
+                      cell.inRange
+                        ? `${cell.date} · ${cell.count}/3 완료`
+                        : undefined
+                    }
+                    className={`rounded-[3px] transition-colors ${
+                      cell.inRange ? cellColor(cell.count) : 'bg-transparent'
+                    }`}
+                    style={{ width: CELL, height: CELL }}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
         </div>
       </div>
 
-      {/* 태스크별 행 */}
-      <div className="flex flex-col gap-5">
-        {rows.map((row) => (
-          <div key={row.taskType}>
-            <p className="mb-1 text-xs font-medium text-slate-500 dark:text-slate-400">
-              {row.label}
-            </p>
-            <div className="flex gap-0">
-              {/* 요일 레이블 */}
-              <div
-                className="mr-[6px] flex flex-col justify-between"
-                style={{ height: 7 * STEP - GAP }}
-              >
-                {DAY_LABELS.map((d, i) => (
-                  <span
-                    key={i}
-                    className="text-[9px] leading-none text-slate-300 dark:text-slate-600"
-                    style={{ height: CELL, lineHeight: `${CELL}px` }}
-                  >
-                    {d}
-                  </span>
-                ))}
-              </div>
-
-              {/* 셀 그리드 */}
-              <div className="flex gap-[2px]">
-                {row.grid.map((week, w) => (
-                  <div key={w} className="flex flex-col gap-[2px]">
-                    {week.map((cell, d) =>
-                      cell ? (
-                        <div
-                          key={d}
-                          title={`${cell.date} · ${cell.completed ? '완료' : '미완료'}`}
-                          className={`rounded-[2px] transition-colors ${
-                            cell.completed
-                              ? 'bg-sky-500'
-                              : 'bg-slate-100 dark:bg-slate-800'
-                          }`}
-                          style={{ width: CELL, height: CELL }}
-                        />
-                      ) : (
-                        <div key={d} style={{ width: CELL, height: CELL }} />
-                      ),
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-
       {/* 범례 */}
-      <div className="mt-4 flex items-center gap-2 text-xs text-slate-400">
-        <span>미완료</span>
-        <div
-          className="rounded-[2px] bg-slate-100 dark:bg-slate-800"
-          style={{ width: CELL, height: CELL }}
-        />
-        <div className="rounded-[2px] bg-sky-500" style={{ width: CELL, height: CELL }} />
-        <span>완료</span>
+      <div className="mt-4 flex items-center gap-2 text-[11px] text-slate-400">
+        <span>Less</span>
+        {([0, 1, 2, 3] as const).map((n) => (
+          <div
+            key={n}
+            className={`rounded-[3px] ${cellColor(n)}`}
+            style={{ width: CELL, height: CELL }}
+          />
+        ))}
+        <span>More</span>
+        <span className="ml-3 text-slate-300 dark:text-slate-600">|</span>
+        <span className="ml-1">색상 = 당일 완료한 태스크 수 (최대 3개)</span>
       </div>
     </div>
   );

--- a/admin/src/app/todo/TaskButton.tsx
+++ b/admin/src/app/todo/TaskButton.tsx
@@ -19,22 +19,22 @@ export function TaskButton({ taskType, label, date, completed }: TaskButtonProps
       type="button"
       disabled={isPending}
       onClick={() => startTransition(() => toggleTask(taskType, date, completed))}
-      className={`flex w-full items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-colors disabled:opacity-60 ${
+      className={`flex min-h-[88px] w-full flex-col items-center justify-center gap-2 rounded-xl p-3 text-center transition-colors disabled:opacity-60 ${
         completed
           ? 'bg-sky-500 text-white hover:bg-sky-600'
-          : 'bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700'
+          : 'bg-slate-100 text-slate-500 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700'
       }`}
     >
       <span
-        className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 text-xs ${
+        className={`flex h-8 w-8 items-center justify-center rounded-full border-2 text-sm font-bold ${
           completed
             ? 'border-white bg-white text-sky-500'
-            : 'border-slate-400 dark:border-slate-500'
+            : 'border-slate-300 dark:border-slate-600'
         }`}
       >
-        {completed && '✓'}
+        {completed ? '✓' : ''}
       </span>
-      {label}
+      <span className="text-xs font-medium leading-tight">{label}</span>
     </button>
   );
 }

--- a/admin/src/components/layout/Sidebar.tsx
+++ b/admin/src/components/layout/Sidebar.tsx
@@ -12,7 +12,7 @@ const navItems = [
   { href: '/courses', label: '코스 관리', icon: Route },
   { href: '/locations/incomplete', label: '데이터 품질', icon: AlertTriangle },
   { href: '/content-engine', label: '콘텐츠 엔진', icon: Bot },
-  { href: '/todo', label: 'Weekly Tasks', icon: CheckSquare },
+  { href: '/todo', label: 'Daily Tasks', icon: CheckSquare },
 ];
 
 export function Sidebar() {


### PR DESCRIPTION
## Summary

- Sidebar 레이블 'Weekly Tasks' → 'Daily Tasks' 수정
- 오늘 체크 버튼을 full-width 스택 → compact 3열 카드로 개선
- 잔디 그래프를 3개 분리 → 단일 통합 히트맵으로 재작성 (강도 기반 sky 색상)
- 이번 주 현황 섹션 신설 (태스크별 streak + 7일 dot 표시)
- 1/182일 misleading 통계 카드 제거

Closes #42

## Test plan

- [ ] `/todo` 접속 → 오늘 버튼 3열 compact 카드 확인
- [ ] 버튼 클릭 → sky-500 완료 상태 토글 확인
- [ ] 이번 주 현황에 streak + 7일 dots 표시 확인
- [ ] 26주 기록 히트맵 셀 색상 강도 확인 (0=gray, 1=sky-200, 2=sky-400, 3=sky-500)
- [ ] 월 레이블 겹침 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)