### PR TITLE
fix: search_logs·click_logs 마이그레이션 + reviews 관리 + Project 컬럼 정리 (#47)

### DIFF
--- a/admin/src/app/reviews/actions.ts
+++ b/admin/src/app/reviews/actions.ts
@@ -1,0 +1,12 @@
+'use server';
+
+import { createServerSupabase } from '@/lib/supabase/server';
+import { revalidatePath } from 'next/cache';
+
+export async function deleteReview(id: string): Promise<{ error: string | null }> {
+  const supabase = await createServerSupabase();
+  const { error } = await supabase.from('reviews').delete().eq('id', id);
+  if (error) return { error: error.message };
+  revalidatePath('/reviews');
+  return { error: null };
+}

--- a/admin/src/app/reviews/page.tsx
+++ b/admin/src/app/reviews/page.tsx
@@ -1,0 +1,116 @@
+import { createServerSupabase } from '@/lib/supabase/server';
+import { getReviews } from '@/lib/queries/reviews';
+import { AdminLayout } from '@/components/layout/AdminLayout';
+import { deleteReview } from './actions';
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+const VISIT_TYPE_LABEL: Record<string, string> = {
+  first: '첫 방문',
+  repeat: '재방문',
+  regular: '단골',
+};
+
+export default async function ReviewsPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const supabase = await createServerSupabase();
+
+  const page = Number(params.page) || 1;
+  const perPage = 30;
+
+  const { data: reviews, count } = await getReviews(supabase, { page, per_page: perPage });
+
+  const totalPages = Math.ceil((count ?? 0) / perPage);
+
+  return (
+    <AdminLayout>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h1 className="text-xl font-bold">리뷰 관리</h1>
+          <span className="text-sm text-muted-foreground">총 {count ?? 0}개</span>
+        </div>
+
+        <div className="rounded-md border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/50">
+                <th className="px-4 py-2 text-left font-medium">장소</th>
+                <th className="px-4 py-2 text-left font-medium">리뷰</th>
+                <th className="px-4 py-2 text-left font-medium">작성자</th>
+                <th className="px-4 py-2 text-left font-medium">방문 유형</th>
+                <th className="px-4 py-2 text-left font-medium">작성일</th>
+                <th className="px-4 py-2 text-left font-medium">삭제</th>
+              </tr>
+            </thead>
+            <tbody>
+              {reviews.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
+                    리뷰가 없습니다.
+                  </td>
+                </tr>
+              ) : (
+                reviews.map((review) => (
+                  <tr key={review.id} className="border-b last:border-0">
+                    <td className="px-4 py-2 font-medium">{review.location_name || '-'}</td>
+                    <td className="px-4 py-2 max-w-xs truncate">{review.one_liner}</td>
+                    <td className="px-4 py-2 text-muted-foreground">{review.user_display_name}</td>
+                    <td className="px-4 py-2">
+                      <span className="rounded-full bg-sky-100 px-2 py-0.5 text-xs text-sky-700">
+                        {VISIT_TYPE_LABEL[review.visit_type] ?? review.visit_type}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2 text-muted-foreground whitespace-nowrap">
+                      {new Date(review.created_at).toLocaleDateString('ko-KR')}
+                    </td>
+                    <td className="px-4 py-2">
+                      <form
+                        action={async () => {
+                          'use server';
+                          await deleteReview(review.id);
+                        }}
+                      >
+                        <button
+                          type="submit"
+                          className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+                        >
+                          삭제
+                        </button>
+                      </form>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2 pt-2">
+            {page > 1 && (
+              <a
+                href={`/reviews?page=${page - 1}`}
+                className="rounded border px-3 py-1 text-sm hover:bg-muted"
+              >
+                이전
+              </a>
+            )}
+            <span className="text-sm text-muted-foreground">
+              {page} / {totalPages}
+            </span>
+            {page < totalPages && (
+              <a
+                href={`/reviews?page=${page + 1}`}
+                className="rounded border px-3 py-1 text-sm hover:bg-muted"
+              >
+                다음
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+    </AdminLayout>
+  );
+}

--- a/admin/src/components/layout/Sidebar.tsx
+++ b/admin/src/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { MapPin, AlertTriangle, Sparkles, Route, Bot, BarChart2, CheckSquare } from 'lucide-react';
+import { MapPin, AlertTriangle, Sparkles, Route, Bot, BarChart2, CheckSquare, MessageSquare } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const navItems = [
@@ -10,6 +10,7 @@ const navItems = [
   { href: '/locations', label: '맛집/카페 관리', icon: MapPin },
   { href: '/attractions', label: '볼거리 관리', icon: Sparkles },
   { href: '/courses', label: '코스 관리', icon: Route },
+  { href: '/reviews', label: '리뷰 관리', icon: MessageSquare },
   { href: '/locations/incomplete', label: '데이터 품질', icon: AlertTriangle },
   { href: '/content-engine', label: '콘텐츠 엔진', icon: Bot },
   { href: '/todo', label: 'Daily Tasks', icon: CheckSquare },

--- a/admin/src/lib/queries/reviews.ts
+++ b/admin/src/lib/queries/reviews.ts
@@ -1,0 +1,61 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface Review {
+  id: string;
+  location_id: string;
+  location_name?: string;
+  user_display_name: string;
+  one_liner: string;
+  visit_type: 'first' | 'repeat' | 'regular';
+  tags: string[];
+  created_at: string;
+}
+
+export async function getReviews(
+  supabase: SupabaseClient,
+  filters: { page?: number; per_page?: number; location_id?: string }
+): Promise<{ data: Review[]; count: number }> {
+  const page = filters.page ?? 1;
+  const perPage = filters.per_page ?? 30;
+  const from = (page - 1) * perPage;
+  const to = from + perPage - 1;
+
+  let query = supabase
+    .from('reviews')
+    .select(
+      `id, location_id, user_display_name, one_liner, visit_type, tags, created_at,
+       locations(name)`,
+      { count: 'exact' }
+    )
+    .order('created_at', { ascending: false })
+    .range(from, to);
+
+  if (filters.location_id) {
+    query = query.eq('location_id', filters.location_id);
+  }
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    console.warn('[getReviews] 쿼리 오류:', error);
+    return { data: [], count: 0 };
+  }
+
+  const rows = (data ?? []) as unknown as (Record<string, unknown> & {
+    locations?: { name: string } | null;
+  })[];
+
+  return {
+    data: rows.map((row) => ({
+      id: row.id as string,
+      location_id: row.location_id as string,
+      location_name: (row.locations as { name?: string } | null)?.name ?? '',
+      user_display_name: (row.user_display_name ?? '익명') as string,
+      one_liner: (row.one_liner ?? '') as string,
+      visit_type: (row.visit_type ?? 'first') as Review['visit_type'],
+      tags: (Array.isArray(row.tags) ? row.tags : []) as string[],
+      created_at: (row.created_at ?? '') as string,
+    })),
+    count: count ?? 0,
+  };
+}

--- a/admin/supabase/migrations/015_search_click_logs.sql
+++ b/admin/supabase/migrations/015_search_click_logs.sql
@@ -1,0 +1,107 @@
+-- ============================================================
+-- 015: search_logs · click_logs · touch_location_activity RPC
+--
+-- Project(Vite) 앱이 사용자 검색/클릭 이벤트를 기록하는 테이블.
+-- touch_location_activity RPC: 장소 클릭/맵 열기 시 location_stats 갱신.
+-- ============================================================
+
+-- ────────────────────────────────────────────────────────────
+-- 1. search_logs: 사용자 검색 1회 = 1행
+--    INSERT at submit → UPDATE on click/map-open
+-- ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS search_logs (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  query            text NOT NULL DEFAULT '',
+  parsed           jsonb DEFAULT NULL,           -- raw LLM 응답 (백엔드 전용)
+  result_count     integer DEFAULT 0,
+  llm_ms           integer DEFAULT 0,
+  db_ms            integer DEFAULT 0,
+  total_ms         integer DEFAULT 0,
+  clicked_place_id uuid REFERENCES locations(id) ON DELETE SET NULL,
+  clicked_rank     integer DEFAULT NULL,
+  opened_map       boolean DEFAULT false,
+  map_provider     text DEFAULT NULL
+                     CHECK (map_provider IS NULL OR map_provider IN ('naver', 'kakao')),
+  created_at       timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_logs_created_at
+  ON search_logs(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_search_logs_clicked_place_id
+  ON search_logs(clicked_place_id);
+
+ALTER TABLE search_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS search_logs_insert ON search_logs;
+CREATE POLICY search_logs_insert
+  ON search_logs FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS search_logs_update ON search_logs;
+CREATE POLICY search_logs_update
+  ON search_logs FOR UPDATE
+  TO anon, authenticated
+  USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS search_logs_select ON search_logs;
+CREATE POLICY search_logs_select
+  ON search_logs FOR SELECT
+  TO authenticated
+  USING (true);
+
+
+-- ────────────────────────────────────────────────────────────
+-- 2. click_logs: 장소별 클릭 액션 기록
+-- ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS click_logs (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  location_id uuid NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+  action_type text NOT NULL
+                CHECK (action_type IN (
+                  'view_detail', 'open_naver', 'open_kakao',
+                  'marker_click', 'list_click', 'copy_address'
+                )),
+  search_id   uuid REFERENCES search_logs(id) ON DELETE SET NULL,
+  created_at  timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_click_logs_location_id
+  ON click_logs(location_id);
+CREATE INDEX IF NOT EXISTS idx_click_logs_created_at
+  ON click_logs(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_click_logs_search_id
+  ON click_logs(search_id);
+
+ALTER TABLE click_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS click_logs_insert ON click_logs;
+CREATE POLICY click_logs_insert
+  ON click_logs FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS click_logs_select ON click_logs;
+CREATE POLICY click_logs_select
+  ON click_logs FOR SELECT
+  TO authenticated
+  USING (true);
+
+
+-- ────────────────────────────────────────────────────────────
+-- 3. touch_location_activity(p_location_id uuid)
+--    장소 클릭/맵 열기 시 location_stats.last_activity_at 갱신
+--    SECURITY DEFINER: anon도 호출 가능, 직접 테이블 쓰기 불필요
+-- ────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION touch_location_activity(p_location_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  INSERT INTO location_stats (location_id, popularity_score, last_activity_at)
+  VALUES (p_location_id, 0, now())
+  ON CONFLICT (location_id)
+  DO UPDATE SET last_activity_at = now();
+END;
+$$;

--- a/admin/supabase/migrations/016_create_reviews.sql
+++ b/admin/supabase/migrations/016_create_reviews.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- 016: reviews 테이블 명시적 생성
+--
+-- Project(Vite) 앱에서 사용자가 장소 리뷰를 작성하는 테이블.
+-- Admin에서 리뷰 목록 조회·삭제 관리.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS reviews (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  location_id       uuid NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+  user_id           uuid DEFAULT NULL,         -- 인증 사용자 (optional)
+  user_display_name text NOT NULL DEFAULT '익명',
+  one_liner         text NOT NULL DEFAULT '',
+  visit_type        text NOT NULL DEFAULT 'first'
+                      CHECK (visit_type IN ('first', 'repeat', 'regular')),
+  tags              text[] DEFAULT '{}',
+  created_at        timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_reviews_location_id
+  ON reviews(location_id);
+CREATE INDEX IF NOT EXISTS idx_reviews_created_at
+  ON reviews(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_reviews_tags_gin
+  ON reviews USING GIN (tags);
+
+ALTER TABLE reviews ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS reviews_insert ON reviews;
+CREATE POLICY reviews_insert
+  ON reviews FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS reviews_select ON reviews;
+CREATE POLICY reviews_select
+  ON reviews FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS reviews_delete ON reviews;
+CREATE POLICY reviews_delete
+  ON reviews FOR DELETE
+  TO authenticated
+  USING (true);

--- a/project/src/utils/supabase.ts
+++ b/project/src/utils/supabase.ts
@@ -28,9 +28,9 @@ export const locationApi = {
     const columns = [
       'id', 'name', 'region', 'sub_region', 'category_main', 'category_sub',
       'lat', 'lon', 'rating', 'curation_level', 'imageUrl', 'tags', 'curator_visited',
-      'trust_score', 'popularity_score',
+      'popularity_score',
       'address', 'memo', 'short_desc', 'price_level', 'event_tags', 'content_type',
-      'naver_place_id', 'kakao_place_id', 'visit_date', 'created_at', 'last_verified_at',
+      'naver_place_id', 'kakao_place_id', 'visit_date', 'created_at',
     ].join(', ');
     let result = await supabase
       .from(searchView)


### PR DESCRIPTION
## Summary

- **015_search_click_logs.sql**: `search_logs`·`click_logs` 테이블 생성 + `touch_location_activity` RPC — Project가 이미 INSERT 중이었으나 마이그레이션 부재로 운영 DB 테이블 없음 상태 해소 (CRITICAL)
- **016_create_reviews.sql**: `reviews` 테이블 명시적 마이그레이션 추가 (IF NOT EXISTS)
- **project/supabase.ts**: `trust_score`·`last_verified_at` SELECT 배열에서 제거 (007에서 DROP된 컬럼)
- **Admin reviews**: 쿼리 레이어·목록 페이지·삭제 액션·Sidebar 링크 신규 추가

## Test plan

- [ ] `npm run build` (admin) ✅ 통과 확인
- [ ] 마이그레이션 파일 SQL 문법 검토
- [ ] Project columns 배열에 trust_score·last_verified_at 없음 확인
- [ ] `/reviews` 페이지 Admin 빌드 경로 존재 확인

closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)