### PR TITLE
fix: savedCourses attractions 검증 + odiga_search_logs preference 컬럼 4개 (#49)

### DIFF
--- a/odiga-api/api/log.ts
+++ b/odiga-api/api/log.ts
@@ -32,6 +32,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     regenerate_count,
     parse_error_fields,
     user_feedbacks,
+    special_context,
+    noise_preference,
+    budget_sensitivity,
+    walking_preference,
   } = req.body || {};
 
   const query = sanitizeQuery(raw_query);
@@ -57,6 +61,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       user_feedbacks: Array.isArray(user_feedbacks)
         ? user_feedbacks.filter((f: unknown) => typeof f === 'string')
         : [],
+      special_context: typeof special_context === 'string' ? special_context : null,
+      noise_preference: typeof noise_preference === 'string' ? noise_preference : null,
+      budget_sensitivity: typeof budget_sensitivity === 'string' ? budget_sensitivity : null,
+      walking_preference: typeof walking_preference === 'string' ? walking_preference : null,
       created_at: new Date().toISOString(),
     };
 

--- a/odiga/supabase/migrations/20260226_01_add_preference_columns.sql
+++ b/odiga/supabase/migrations/20260226_01_add_preference_columns.sql
@@ -1,0 +1,19 @@
+-- odiga: intent 파싱 결과 preference 컬럼 4개 추가
+--
+-- intent.ts가 파싱하는 special_context·noise_preference·
+-- budget_sensitivity·walking_preference가 log.ts에서 삽입되나
+-- 스키마에 컬럼이 없어 데이터가 유실되던 문제 수정.
+
+ALTER TABLE odiga_search_logs
+  ADD COLUMN IF NOT EXISTS special_context      text DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS noise_preference     text DEFAULT NULL
+    CHECK (noise_preference IS NULL OR noise_preference IN ('quiet', 'balanced', 'lively', 'unknown')),
+  ADD COLUMN IF NOT EXISTS budget_sensitivity   text DEFAULT NULL
+    CHECK (budget_sensitivity IS NULL OR budget_sensitivity IN ('tight', 'moderate', 'flexible', 'unknown')),
+  ADD COLUMN IF NOT EXISTS walking_preference   text DEFAULT NULL
+    CHECK (walking_preference IS NULL OR walking_preference IN ('short', 'moderate', 'relaxed', 'unknown'));
+
+CREATE INDEX IF NOT EXISTS idx_odiga_search_logs_noise_preference
+  ON odiga_search_logs (noise_preference);
+CREATE INDEX IF NOT EXISTS idx_odiga_search_logs_budget_sensitivity
+  ON odiga_search_logs (budget_sensitivity);


### PR DESCRIPTION
## Summary

- **savedCourses.ts**: `verifyCoursePlacesExist()` — `locations`만 확인하던 로직에 `attractions` 병렬 조회 추가, 두 테이블 foundIds 합집합으로 검증
- **20260226_01_add_preference_columns.sql**: `odiga_search_logs`에 `special_context`·`noise_preference`·`budget_sensitivity`·`walking_preference` 컬럼 4개 추가 (CHECK constraint 포함)
- **log.ts**: 4개 preference 필드 destructuring 및 entry 객체에 추가

## Test plan

- [ ] attractions 장소 ID가 포함된 코스 저장 시 `missing_place_ids` 오류 없음
- [ ] `odiga_search_logs` 마이그레이션 SQL 문법 검토
- [ ] log.ts TypeScript 타입 오류 없음 확인

closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)