### PR TITLE
fix(ux): P0/P1 접근성 개선 — 키보드 접근성, 터치 타겟, alert() 제거

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -41,6 +41,9 @@ export default function App() {
   // Modal state
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  // 결과 없음 메시지 상태 (alert() 대체)
+  const [noResultMessage, setNoResultMessage] = useState<string | null>(null);
+
   /** Decision STEP1: 시/도별 세부지역. 전국구로 시/도 먼저 보여주고, 클릭 시 세부지역 펼침 */
   const availableProvincesWithDistricts: { province: Province; districts: string[] }[] = (() => {
     const regionSet = new Set(locations.map((l) => l.region).filter(Boolean));
@@ -350,14 +353,14 @@ export default function App() {
       return;
     }
 
+    setNoResultMessage(null);
     const result = decideLocations(locations, companion, timeSlot, priorityFeature, region);
     if (result) {
       setDecisionResult(result);
       setUiMode('result');
     } else {
-      // 결과 없음: 사용자에게 알림 후 browse 모드로 전환
-      alert('조건에 맞는 장소가 아직 없어요. 직접 둘러볼까요?');
-      setUiMode('browse');
+      // 결과 없음: 인라인 메시지로 알림, decision 화면에 그대로 머묾
+      setNoResultMessage('조건에 맞는 장소가 아직 없어요. 필터를 바꾸거나 직접 둘러볼까요?');
     }
   }, [contentMode, locations]);
 
@@ -478,6 +481,7 @@ export default function App() {
           availableProvincesWithDistricts={availableProvincesWithDistricts}
           onDecide={handleDecide}
           onBrowse={handleSwitchToBrowse}
+          noResultMessage={noResultMessage}
         />
       )}
 

--- a/project/src/components/AddLocationModal.tsx
+++ b/project/src/components/AddLocationModal.tsx
@@ -1,4 +1,5 @@
 import { X } from 'lucide-react';
+import { useEffect } from 'react';
 import { CustomSelect } from './CustomSelect';
 import { ImageUpload } from './ImageUpload';
 import type { Province, CategoryMain, CategorySub, ContentMode } from '../types/location';
@@ -39,6 +40,15 @@ export function AddLocationModal({ contentMode, onClose, onSave, existingLocatio
     handleSubmit,
   } = useAddLocationForm({ existingLocations, onSave, onClose, contentMode });
 
+  // ESC 키로 모달 닫기
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
   const presetTags = contentMode === 'space'
     ? ['벚꽃', '야경', '전시', '포토스팟', '데이트', '산책', '실내', '비오는날', '주말코스', '혼자']
     : ['벚꽃', '데이트', '혼밥', '조용한 분위기', '웨이팅 적음', '가성비', '브런치', '야식', '예약 가능', '주차 가능'];
@@ -53,7 +63,8 @@ export function AddLocationModal({ contentMode, onClose, onSave, existingLocatio
           </h2>
           <button
             onClick={onClose}
-            className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-gray-100 transition-colors"
+            aria-label="닫기"
+            className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-gray-100 transition-colors"
           >
             <X size={20} className="text-gray-500" />
           </button>

--- a/project/src/components/BrowseConfirmView.tsx
+++ b/project/src/components/BrowseConfirmView.tsx
@@ -59,10 +59,10 @@ export function BrowseConfirmView({
             다시 정해줘
           </button>
 
-          {/* Secondary: Browse 진입 (작고 muted) */}
+          {/* Secondary: Browse 진입 (작고 muted, 터치 타겟 44px 확보) */}
           <button
             onClick={onProceedToBrowse}
-            className="text-sm text-gray-400 transition-colors hover:text-gray-500"
+            className="min-h-[44px] px-4 text-sm text-gray-400 transition-colors hover:text-gray-500"
           >
             직접 둘러보기
           </button>

--- a/project/src/components/DecisionEntryView.tsx
+++ b/project/src/components/DecisionEntryView.tsx
@@ -32,6 +32,8 @@ interface DecisionEntryViewProps {
   ) => void;
   /** "직접 둘러보기" 클릭 시 호출 → browse 모드로 전환 */
   onBrowse: () => void;
+  /** 결과 없음 알림 메시지 (alert() 대체 인라인 메시지) */
+  noResultMessage?: string | null;
 }
 
 // ─────────────────────────────────────────────
@@ -70,6 +72,7 @@ export function DecisionEntryView({
   availableProvincesWithDistricts,
   onDecide,
   onBrowse,
+  noResultMessage,
 }: DecisionEntryViewProps) {
   const [region, setRegion] = useState<string>(REGION_ANY_VALUE);
   const [expandedProvince, setExpandedProvince] = useState<Province | null>(null);
@@ -113,7 +116,7 @@ export function DecisionEntryView({
         step1: '어디로 나들이 갈래?',
         cta: '지금 바로 정해줘',
         browse: '직접 둘러보기',
-        accent: 'violet',
+        accent: 'violet' as const,
       };
     }
 
@@ -121,7 +124,7 @@ export function DecisionEntryView({
       step1: '어디서 먹고 싶어?',
       cta: '지금 바로 정해줘',
       browse: '직접 둘러보기',
-      accent: 'orange',
+      accent: 'orange' as const,
     };
   }, [contentMode]);
 
@@ -241,6 +244,7 @@ export function DecisionEntryView({
           <button
             onClick={handleDecide}
             disabled={!isComplete}
+            aria-disabled={!isComplete}
             className={`
               w-full rounded-2xl py-4 text-base font-semibold tracking-tight transition-all duration-200
               ${isComplete
@@ -253,9 +257,19 @@ export function DecisionEntryView({
           >
             {modeText.cta}
           </button>
+          {!isComplete && (
+            <p className="text-xs text-gray-400" role="status" aria-live="polite">
+              {!companion ? '동행을 선택해주세요' : !timeSlot ? '시간대를 선택해주세요' : '우선 조건을 선택해주세요'}
+            </p>
+          )}
+          {noResultMessage && (
+            <p className="w-full rounded-xl bg-amber-50 px-4 py-2.5 text-center text-xs text-amber-700" role="alert" aria-live="assertive">
+              {noResultMessage}
+            </p>
+          )}
           <button
             onClick={onBrowse}
-            className="text-sm text-gray-400 transition-colors hover:text-gray-600"
+            className="min-h-[44px] px-4 text-sm text-gray-400 transition-colors hover:text-gray-600"
           >
             {modeText.browse}
           </button>
@@ -317,7 +331,7 @@ function PillGroup<T extends string>({ options, accent, selected, onSelect }: Pi
             key={option.value}
             onClick={() => onSelect(option.value)}
             className={`
-              rounded-full border px-5 py-2.5 text-sm font-medium transition-all duration-150
+              rounded-full border px-5 py-3 text-sm font-medium transition-all duration-150
               ${isSelected
                 ? accent === 'violet'
                   ? 'border-violet-600 bg-violet-600 text-white'

--- a/project/src/components/DecisionResultView.tsx
+++ b/project/src/components/DecisionResultView.tsx
@@ -154,8 +154,10 @@ function PrimaryCard({ location, reason, onOpenDetail }: PrimaryCardProps) {
   const activeTags = [...new Set([...(location.tags || []), ...(location.eventTags || [])])].slice(0, 4);
 
   return (
-    <div
-      className="cursor-pointer overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm transition-shadow hover:shadow-md"
+    <button
+      type="button"
+      aria-label={`${location.name} 상세 보기`}
+      className="w-full cursor-pointer overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm transition-shadow hover:shadow-md text-left"
       onClick={() => onOpenDetail(location)}
     >
       {/* 이미지 */}
@@ -221,7 +223,7 @@ function PrimaryCard({ location, reason, onOpenDetail }: PrimaryCardProps) {
           </div>
         )}
       </div>
-    </div>
+    </button>
   );
 }
 

--- a/project/src/components/PlaceDetail.tsx
+++ b/project/src/components/PlaceDetail.tsx
@@ -25,6 +25,15 @@ export function PlaceDetail({ location, onClose, isMobile = false, searchId }: P
   const [copied, setCopied] = useState(false);
   const [imageError, setImageError] = useState(false);
 
+  // ESC 키로 모달 닫기
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
   // 리뷰 데이터 로드
   useEffect(() => {
     const loadReviews = async () => {
@@ -98,7 +107,8 @@ export function PlaceDetail({ location, onClose, isMobile = false, searchId }: P
         <div className="bg-white border-b border-base px-4 py-3 flex items-center justify-between flex-shrink-0">
           <button
             onClick={onClose}
-            className="w-10 h-10 flex items-center justify-center rounded-xl hover:bg-base transition-colors"
+            aria-label="닫기"
+            className="w-11 h-11 flex items-center justify-center rounded-xl hover:bg-base transition-colors"
           >
             <X size={24} className="text-accent/80" />
           </button>


### PR DESCRIPTION
## Summary
- PrimaryCard `<div onClick>` → `<button>` 으로 키보드 탭 포커스 복구 (P0)
- PlaceDetail / AddLocationModal ESC 키 닫기 추가 (P0)
- 터치 타겟 미달 버튼 전반 44px 이상으로 확대 (P1)
- `alert()` 완전 제거 → `role="alert"` 인라인 amber 배너로 대체 (P1)
- 닫기 버튼 `aria-label="닫기"` + 크기 `w-11 h-11` 통일 (P1)

## Test plan
- [ ] `npm run build` 통과 ✅
- [ ] DecisionResultView PrimaryCard 키보드(Tab→Enter) 동작 확인
- [ ] PlaceDetail/AddLocationModal ESC 키 닫기 동작 확인
- [ ] 조건 선택 완료 후 결과 없을 때 amber 배너 표시, alert() 미호출 확인
- [ ] 닫기 버튼 44px 터치 타겟 확인

closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)