### PR TITLE
fix(ux): P3 접근성 마무리 — AddReviewModal + BrowseView aria 개선

### DIFF
--- a/project/src/components/AddReviewModal.tsx
+++ b/project/src/components/AddReviewModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { X, CheckCircle, RefreshCw } from 'lucide-react';
 import type { Review, VisitType } from '../types/location';
 import { reviewApi } from '../utils/supabase';
@@ -35,6 +35,15 @@ export function AddReviewModal({
   const [confirmed, setConfirmed] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState('');
+
+  // ESC 키로 모달 닫기
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
 
   const toggleTag = (tag: string) => {
     setSelectedTags((prev) => {
@@ -97,8 +106,10 @@ export function AddReviewModal({
         <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
           <h2 className="text-lg font-bold text-gray-900">나도 다녀왔어요</h2>
           <button
+            type="button"
             onClick={onClose}
-            className="w-9 h-9 flex items-center justify-center rounded-xl hover:bg-gray-100 transition-colors"
+            aria-label="닫기"
+            className="w-11 h-11 flex items-center justify-center rounded-xl hover:bg-gray-100 transition-colors"
           >
             <X size={20} className="text-gray-500" />
           </button>
@@ -215,7 +226,7 @@ export function AddReviewModal({
 
           {/* 에러 메시지 */}
           {error && (
-            <div className="bg-red-50 border border-red-200 rounded-xl px-4 py-3">
+            <div role="alert" className="bg-red-50 border border-red-200 rounded-xl px-4 py-3">
               <p className="text-sm text-red-600">{error}</p>
             </div>
           )}
@@ -230,8 +241,10 @@ export function AddReviewModal({
             취소
           </button>
           <button
+            type="button"
             onClick={handleSubmit}
             disabled={isSubmitting}
+            aria-disabled={isSubmitting}
             className="flex-1 py-3 bg-orange-500 text-white font-medium rounded-xl hover:bg-orange-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isSubmitting ? '저장 중...' : '등록하기'}

--- a/project/src/components/BrowseView.tsx
+++ b/project/src/components/BrowseView.tsx
@@ -147,8 +147,10 @@ export function BrowseView({
               />
               {searchQuery && (
                 <button
+                  type="button"
                   onClick={() => setSearchQuery('')}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-gray-500"
+                  aria-label="검색 초기화"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-gray-300 hover:text-gray-500"
                 >
                   <X size={16} />
                 </button>
@@ -159,7 +161,10 @@ export function BrowseView({
           {/* ── 필터 (접힘 상태 기본, 높은 마찰) ── */}
           <div className="mb-4">
             <button
+              type="button"
               onClick={() => setIsFilterExpanded(!isFilterExpanded)}
+              aria-expanded={isFilterExpanded}
+              aria-controls="browse-filter-section"
               className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-2 text-xs font-medium text-gray-500 transition-colors hover:border-gray-300 hover:text-gray-600"
             >
               <span>조건 변경</span>
@@ -170,7 +175,7 @@ export function BrowseView({
             </button>
 
             {isFilterExpanded && (
-              <div className="mt-3 rounded-xl border border-gray-100 bg-gray-50/50 p-4">
+              <div id="browse-filter-section" className="mt-3 rounded-xl border border-gray-100 bg-gray-50/50 p-4">
                 <FilterSection
                   selectedProvince={resolvedSelectedProvince}
                   onProvinceChange={resolvedOnProvinceChange}
@@ -216,6 +221,11 @@ export function BrowseView({
               onShowMore={onShowMore}
               onSelect={handleLocationSelect}
               selectedId={selectedLocation?.id}
+              emptyMessage={
+                searchQuery
+                  ? `'${searchQuery}'에 맞는 장소가 없어요. 검색어를 바꿔보세요.`
+                  : '조건에 맞는 장소가 없어요.'
+              }
             />
           </div>
         </div>
@@ -266,6 +276,7 @@ interface BrowseListProps {
   onShowMore: () => void;
   onSelect: (location: Location) => void;
   selectedId?: string;
+  emptyMessage?: string;
 }
 
 function BrowseList({
@@ -274,11 +285,12 @@ function BrowseList({
   onShowMore,
   onSelect,
   selectedId,
+  emptyMessage = '조건에 맞는 장소가 없어요.',
 }: BrowseListProps) {
   if (locations.length === 0) {
     return (
       <div className="py-12 text-center text-sm text-gray-400">
-        조건에 맞는 장소가 없습니다.
+        {emptyMessage}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- AddReviewModal 닫기 44px + ESC 키 + `role="alert"` + `aria-disabled`
- BrowseView 검색/필터 버튼 aria 속성 + 검색어별 빈 상태 문구

## Test plan
- [ ] `npm run build` 통과 ✅
- [ ] AddReviewModal: ESC 키로 닫기 동작 확인
- [ ] AddReviewModal: 한 줄 후기 미입력 제출 → 에러 배너 즉시 표시 확인
- [ ] BrowseView: 검색어 입력 후 초기화 버튼 탭+엔터 동작 확인
- [ ] BrowseView: 존재하지 않는 검색어 → `'XXX'에 맞는 장소가 없어요.` 표시 확인

closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)